### PR TITLE
feat(epic16): per-resource annotation control — enabled, skip-until, priority

### DIFF
--- a/README-LLM.md
+++ b/README-LLM.md
@@ -871,6 +871,7 @@ kubectl apply -k deploy/kustomize/
 | `main` | Stable code | Active | 2026-02-19 |
 | `feature/epic11-13-deferred` | Epic 11 (cascade prevention) + Epic 13 (multi-signal correlation) — deferred | Deferred | 2026-02-23 |
 | `feature/epic12-security-remediation` | Epic 12 security gap remediation (findings 001–013) | Active | 2026-02-23 |
+| `feature/epic16-annotation-control` | Epic 16 per-resource annotation control (enabled, skip-until, priority) | Active | 2026-02-24 |
 
 **Merged branches:**
 

--- a/docs/BACKLOG/epic16-annotation-control/README.md
+++ b/docs/BACKLOG/epic16-annotation-control/README.md
@@ -14,7 +14,7 @@ Without this, operators have no per-resource escape hatch. A canary pod that cra
 by design, a load-test Job, or a resource under active manual investigation will
 continuously trigger new `RemediationJob` objects that have to be manually deleted.
 
-## Status: Not Started
+## Status: Complete
 
 ## Deep-Dive Findings (2026-02-23)
 
@@ -65,9 +65,9 @@ continuously trigger new `RemediationJob` objects that have to be manually delet
 
 | Story | File | Status |
 |-------|------|--------|
-| Domain — annotation constants and skip logic | [STORY_01_annotation_constants.md](STORY_01_annotation_constants.md) | Not Started |
-| Providers — ExtractFinding annotation gate | [STORY_02_provider_gate.md](STORY_02_provider_gate.md) | Not Started |
-| Reconciler — priority annotation bypasses stabilisation window | [STORY_03_priority_bypass.md](STORY_03_priority_bypass.md) | Not Started |
+| Domain — annotation constants and skip logic | [STORY_01_annotation_constants.md](STORY_01_annotation_constants.md) | Complete |
+| Providers — ExtractFinding annotation gate | [STORY_02_provider_gate.md](STORY_02_provider_gate.md) | Complete |
+| Reconciler — priority annotation bypasses stabilisation window | [STORY_03_priority_bypass.md](STORY_03_priority_bypass.md) | Complete |
 
 ## Implementation Order
 

--- a/docs/BACKLOG/epic16-annotation-control/STORY_01_annotation_constants.md
+++ b/docs/BACKLOG/epic16-annotation-control/STORY_01_annotation_constants.md
@@ -2,7 +2,7 @@
 
 **Epic:** [epic16-annotation-control](README.md)
 **Priority:** High
-**Status:** Not Started
+**Status:** Complete
 **Estimated Effort:** 1 hour
 
 ---
@@ -105,17 +105,17 @@ inclusive end date.
 
 ## Acceptance Criteria
 
-- [ ] `internal/domain/annotations.go` is a new file in the `domain` package
-- [ ] It exports exactly three constants: `AnnotationEnabled`, `AnnotationSkipUntil`,
+- [x] `internal/domain/annotations.go` is a new file in the `domain` package
+- [x] It exports exactly three constants: `AnnotationEnabled`, `AnnotationSkipUntil`,
   `AnnotationPriority`
-- [ ] It exports `ShouldSkip(annotations map[string]string, now time.Time) bool`
-- [ ] `ShouldSkip` returns `true` when `mendabot.io/enabled` is `"false"`
-- [ ] `ShouldSkip` returns `true` when `mendabot.io/skip-until` is a future date
-- [ ] `ShouldSkip` returns `false` when `mendabot.io/skip-until` is today-or-past
+- [x] It exports `ShouldSkip(annotations map[string]string, now time.Time) bool`
+- [x] `ShouldSkip` returns `true` when `mendabot.io/enabled` is `"false"`
+- [x] `ShouldSkip` returns `true` when `mendabot.io/skip-until` is a future date
+- [x] `ShouldSkip` returns `false` when `mendabot.io/skip-until` is today-or-past
   (window expired at midnight UTC)
-- [ ] `ShouldSkip` returns `false` when `mendabot.io/skip-until` is malformed
-- [ ] `ShouldSkip` returns `false` when no relevant annotations are present
-- [ ] `internal/domain/annotations_test.go` covers all five cases above
+- [x] `ShouldSkip` returns `false` when `mendabot.io/skip-until` is malformed
+- [x] `ShouldSkip` returns `false` when no relevant annotations are present
+- [x] `internal/domain/annotations_test.go` covers all five cases above
 
 ---
 
@@ -142,11 +142,11 @@ All tests live in `internal/domain/annotations_test.go`.
 
 ## Tasks
 
-- [ ] Write `internal/domain/annotations_test.go` covering all cases above (TDD — verify
+- [x] Write `internal/domain/annotations_test.go` covering all cases above (TDD — verify
   they fail before creating the implementation)
-- [ ] Create `internal/domain/annotations.go` with the three constants and `ShouldSkip`
-- [ ] Run `go test -race ./internal/domain/...` — all tests must pass
-- [ ] Run `go vet ./internal/domain/...` — must be clean
+- [x] Create `internal/domain/annotations.go` with the three constants and `ShouldSkip`
+- [x] Run `go test -race ./internal/domain/...` — all tests must pass
+- [x] Run `go vet ./internal/domain/...` — must be clean
 
 ---
 
@@ -159,7 +159,7 @@ All tests live in `internal/domain/annotations_test.go`.
 
 ## Definition of Done
 
-- [ ] `internal/domain/annotations.go` compiles cleanly
-- [ ] All annotation tests pass with `-race`
-- [ ] Full test suite `go test -race ./...` passes
-- [ ] `go vet ./...` clean
+- [x] `internal/domain/annotations.go` compiles cleanly
+- [x] All annotation tests pass with `-race`
+- [x] Full test suite `go test -race ./...` passes
+- [x] `go vet ./...` clean

--- a/docs/BACKLOG/epic16-annotation-control/STORY_02_provider_gate.md
+++ b/docs/BACKLOG/epic16-annotation-control/STORY_02_provider_gate.md
@@ -2,7 +2,7 @@
 
 **Epic:** [epic16-annotation-control](README.md)
 **Priority:** High
-**Status:** Not Started
+**Status:** Complete
 **Estimated Effort:** 1 hour
 
 ---

--- a/docs/BACKLOG/epic16-annotation-control/STORY_03_priority_bypass.md
+++ b/docs/BACKLOG/epic16-annotation-control/STORY_03_priority_bypass.md
@@ -2,7 +2,7 @@
 
 **Epic:** [epic16-annotation-control](README.md)
 **Priority:** High
-**Status:** Not Started
+**Status:** Complete
 **Estimated Effort:** 1 hour
 
 ---

--- a/docs/WORKLOGS/0072_2026-02-24_epic16-story01-annotation-constants.md
+++ b/docs/WORKLOGS/0072_2026-02-24_epic16-story01-annotation-constants.md
@@ -1,0 +1,99 @@
+# Worklog: Epic 16 STORY_01 — Annotation Constants and Skip Logic
+
+**Date:** 2026-02-24
+**Session:** Implement domain annotation constants and ShouldSkip helper (TDD)
+**Status:** Complete
+
+---
+
+## Objective
+
+Implement `internal/domain/annotations.go` with three exported annotation key constants
+(`AnnotationEnabled`, `AnnotationSkipUntil`, `AnnotationPriority`) and the `ShouldSkip`
+helper function. Write `internal/domain/annotations_test.go` first per TDD protocol,
+covering all 7 test cases from the story spec.
+
+---
+
+## Work Completed
+
+### 1. Test file (TDD — written before implementation)
+
+Created `internal/domain/annotations_test.go` with a table-driven `TestShouldSkip`
+covering all 7 required cases:
+
+- `SkipWhenDisabled`
+- `SkipWhenSkipUntilInFuture`
+- `NoSkipWhenSkipUntilInPast`
+- `NoSkipWhenSkipUntilMalformed`
+- `NoSkipWhenNoAnnotations`
+- `SkipOnTheDateItself` (boundary: last second of the annotated day)
+- `NoSkipDayAfter` (boundary: midnight UTC after the annotated day)
+
+Tests failed at build with `undefined: AnnotationEnabled`, `undefined: AnnotationSkipUntil`,
+`undefined: ShouldSkip` — confirming TDD pre-condition met.
+
+### 2. Implementation file
+
+Created `internal/domain/annotations.go` with:
+- Three exported `const` values: `AnnotationEnabled`, `AnnotationSkipUntil`, `AnnotationPriority`
+- `ShouldSkip(annotations map[string]string, now time.Time) bool` with godoc
+- No inline comments on constants per README-LLM.md §4 (no comments unless strictly necessary)
+- Only `"time"` import — zero circular dependency risk
+
+---
+
+## Key Decisions
+
+- Inline comments stripped from constants: story doc showed them but README-LLM.md §4
+  forbids comments unless strictly necessary. The godoc on `ShouldSkip` is retained as it
+  documents the boundary semantics which are non-obvious.
+- `now` passed as parameter (not `time.Now()`) as specified, enabling deterministic tests
+  without monkey-patching.
+- `skip-until` deadline: `t.UTC().AddDate(0, 0, 1)` — window expires at midnight UTC on
+  the day after the annotated date. Malformed values silently treated as absent.
+
+---
+
+## Blockers
+
+None.
+
+---
+
+## Tests Run
+
+```
+go test -timeout 30s -race ./internal/domain/...
+# BEFORE implementation: build failed (undefined symbols) ✓ TDD confirmed
+
+go test -timeout 30s -race ./internal/domain/...
+# AFTER implementation: ok  github.com/lenaxia/k8s-mendabot/internal/domain  1.379s ✓
+
+go vet ./internal/domain/...
+# Clean — no output ✓
+
+go build ./...
+# Clean — no output ✓
+
+go test -timeout 30s -race ./...
+# All 12 packages pass ✓
+```
+
+---
+
+## Next Steps
+
+- STORY_02: Add `ShouldSkip` gate to all 6 native providers in `internal/provider/native/`
+  immediately before the concrete type assertion in each `ExtractFinding` method.
+- STORY_03: Add priority bypass in `internal/provider/provider.go` at the stabilisation
+  window block (lines 167–181), using `domain.AnnotationPriority`.
+
+---
+
+## Files Modified
+
+- `internal/domain/annotations.go` — created
+- `internal/domain/annotations_test.go` — created
+- `docs/WORKLOGS/0072_2026-02-24_epic16-story01-annotation-constants.md` — created
+- `docs/WORKLOGS/README.md` — index table updated

--- a/docs/WORKLOGS/0073_2026-02-24_epic16-annotation-control-complete.md
+++ b/docs/WORKLOGS/0073_2026-02-24_epic16-annotation-control-complete.md
@@ -1,0 +1,128 @@
+# Worklog: Epic 16 — Resource Annotation Control Complete
+
+**Date:** 2026-02-24
+**Session:** Orchestrated full epic16 implementation across 3 stories, 2-pass skeptical review, 4-gap remediation
+**Status:** Complete
+
+---
+
+## Objective
+
+Implement epic16-annotation-control: allow operators to annotate Kubernetes resources with `mendabot.io/enabled`, `mendabot.io/skip-until`, and `mendabot.io/priority` to suppress or fast-track mendabot investigations.
+
+---
+
+## Work Completed
+
+### 1. Branch
+
+- Created `feature/epic16-annotation-control` from `main`
+- Recorded in README-LLM.md branch table
+
+### 2. STORY_01 — Domain annotation constants and skip logic
+
+- New file: `internal/domain/annotations.go`
+  - `AnnotationEnabled = "mendabot.io/enabled"`
+  - `AnnotationSkipUntil = "mendabot.io/skip-until"`
+  - `AnnotationPriority = "mendabot.io/priority"`
+  - `ShouldSkip(annotations map[string]string, now time.Time) bool`
+- New file: `internal/domain/annotations_test.go` — 8 table-driven cases (7 original + nil-map gap fix)
+- TDD: tests written and confirmed failing before implementation
+
+### 3. STORY_02 — Provider annotation gate
+
+- Modified all 6 native providers: `pod.go`, `deployment.go`, `statefulset.go`, `job.go`, `node.go`, `pvc.go`
+- `domain.ShouldSkip(obj.GetAnnotations(), time.Now())` added as the first statement in each `ExtractFinding`, before any type assertion
+- `"time"` import added to each file
+- 2 new tests per provider (12 total) in respective `_test.go` files
+
+### 4. STORY_03 — Priority bypass in reconciler
+
+- Modified `internal/provider/provider.go`
+- Replaced `if r.Cfg.StabilisationWindow != 0 { ... }` with `priorityCritical := obj.GetAnnotations()[domain.AnnotationPriority] == "critical"` + `if !priorityCritical && r.Cfg.StabilisationWindow != 0 { ... }`
+- 2 new tests in `internal/provider/provider_test.go`: `TestStabilisationWindow_PriorityCriticalBypassesWindow`, `TestStabilisationWindow_PriorityCriticalWindowAlreadyZero`
+
+### 5. Skeptical review — 4 gaps found and fixed
+
+**Gap 1 (Major):** `AnnotationEnabled_False` tests in all 6 providers used healthy objects. Fixed by replacing with unhealthy objects that would produce findings without the annotation.
+
+**Gap 2 (Major):** No end-to-end integration test wiring a real native provider through the reconciler with an annotated object. Fixed by adding `TestAnnotationGate_EnabledFalse_NoRemediationJob` to `internal/provider/provider_test.go` using a real `podProvider` with a CrashLoopBackOff pod annotated `mendabot.io/enabled: "false"`.
+
+**Gap 3 (Minor):** Native provider test files used raw string literals for annotation keys. Fixed by replacing with `domain.AnnotationEnabled` and `domain.AnnotationSkipUntil` constants throughout.
+
+**Gap 4 (Minor):** `annotations_test.go` tested empty map but not nil map. Fixed by adding `NoSkipWhenNilAnnotations` test case.
+
+---
+
+## Key Decisions
+
+- `ShouldSkip` receives `now time.Time` as a parameter rather than calling `time.Now()` internally. This keeps the domain layer deterministically testable without monkey-patching.
+- `skip-until` window is inclusive: a resource annotated `2025-06-01` is skipped until `2025-06-02T00:00:00Z` (deadline = `t.UTC().AddDate(0,0,1)`). This is the least surprising interpretation of an inclusive end date.
+- Malformed `skip-until` values are silently ignored (no suppression). This prevents a typo from permanently disabling investigations.
+- `AnnotationPriority` is read by the reconciler only (STORY_03), not by `ExtractFinding`. The provider gate handles suppression; the reconciler handles acceleration. Orthogonal concerns, cleanly separated.
+- The `AnnotationEnabled_False` integration test (Gap 2 fix) uses a real `podProvider`, not the fakeSourceProvider, to prove the annotation gate in the provider code path is actually wired into the reconciler's behaviour.
+
+---
+
+## Blockers
+
+None.
+
+---
+
+## Tests Run
+
+```
+go test -timeout 60s -race ./...
+ok  github.com/lenaxia/k8s-mendabot/api/v1alpha1
+ok  github.com/lenaxia/k8s-mendabot/cmd/watcher
+ok  github.com/lenaxia/k8s-mendabot/internal/config
+ok  github.com/lenaxia/k8s-mendabot/internal/controller
+ok  github.com/lenaxia/k8s-mendabot/internal/domain
+ok  github.com/lenaxia/k8s-mendabot/internal/jobbuilder
+ok  github.com/lenaxia/k8s-mendabot/internal/logging
+ok  github.com/lenaxia/k8s-mendabot/internal/provider
+ok  github.com/lenaxia/k8s-mendabot/internal/provider/native
+ok  github.com/lenaxia/k8s-mendabot/internal/readiness
+ok  github.com/lenaxia/k8s-mendabot/internal/readiness/llm
+ok  github.com/lenaxia/k8s-mendabot/internal/readiness/sink
+```
+
+12/12 packages pass. Race detector clean.
+
+---
+
+## Next Steps
+
+Epic 16 is complete and the branch is ready to merge to `main`. The next epic in the backlog is epic15-namespace-filtering (depends on `internal/domain/` — now a natural neighbour to epic16) or epic17 (dead-letter queue — already complete on `main`). Verify merge order by checking the branch table and FEATURE_TRACKER.md.
+
+---
+
+## Files Modified
+
+| File | Action |
+|------|--------|
+| `internal/domain/annotations.go` | Created |
+| `internal/domain/annotations_test.go` | Created (8 test cases) |
+| `internal/provider/native/pod.go` | Modified (ShouldSkip guard) |
+| `internal/provider/native/pod_test.go` | Modified (2 annotation tests, Gap 1 fix, Gap 3 fix) |
+| `internal/provider/native/deployment.go` | Modified (ShouldSkip guard) |
+| `internal/provider/native/deployment_test.go` | Modified (2 annotation tests, Gap 1 fix, Gap 3 fix) |
+| `internal/provider/native/statefulset.go` | Modified (ShouldSkip guard) |
+| `internal/provider/native/statefulset_test.go` | Modified (2 annotation tests, Gap 1 fix, Gap 3 fix) |
+| `internal/provider/native/job.go` | Modified (ShouldSkip guard) |
+| `internal/provider/native/job_test.go` | Modified (2 annotation tests, Gap 1 fix, Gap 3 fix) |
+| `internal/provider/native/node.go` | Modified (ShouldSkip guard) |
+| `internal/provider/native/node_test.go` | Modified (2 annotation tests, Gap 1 fix, Gap 3 fix) |
+| `internal/provider/native/pvc.go` | Modified (ShouldSkip guard) |
+| `internal/provider/native/pvc_test.go` | Modified (2 annotation tests, Gap 1 fix, Gap 3 fix) |
+| `internal/provider/provider.go` | Modified (priority bypass) |
+| `internal/provider/provider_test.go` | Modified (2 priority tests + 1 integration e2e test) |
+| `docs/BACKLOG/epic16-annotation-control/README.md` | Updated (status: Complete, story table) |
+| `docs/BACKLOG/epic16-annotation-control/STORY_01_annotation_constants.md` | Updated (status: Complete) |
+| `docs/BACKLOG/epic16-annotation-control/STORY_02_provider_gate.md` | Updated (status: Complete) |
+| `docs/BACKLOG/epic16-annotation-control/STORY_03_priority_bypass.md` | Updated (status: Complete) |
+| `README-LLM.md` | Updated (branch table) |
+| `docs/WORKLOGS/0072_2026-02-24_epic16-story01-annotation-constants.md` | Created (by delegate) |
+| `docs/WORKLOGS/0073_2026-02-24_epic16-annotation-control-complete.md` | Created (this file) |
+| `docs/WORKLOGS/README.md` | Updated (index table) |

--- a/internal/domain/annotations.go
+++ b/internal/domain/annotations.go
@@ -1,0 +1,39 @@
+package domain
+
+import "time"
+
+const (
+	AnnotationEnabled   = "mendabot.io/enabled"
+	AnnotationSkipUntil = "mendabot.io/skip-until"
+	AnnotationPriority  = "mendabot.io/priority"
+)
+
+// ShouldSkip reports whether ExtractFinding should return (nil, nil) for the
+// resource that owns annotations, based on the mendabot.io control annotations.
+//
+// Rules (evaluated in order):
+//  1. If annotations["mendabot.io/enabled"] == "false"  → skip (return true).
+//  2. If annotations["mendabot.io/skip-until"] is set:
+//     - Parse the value as "2006-01-02" in UTC.
+//     - If parsing fails: do NOT skip (treat as absent).
+//     - If now is before the end of the skip-until day (i.e. before midnight
+//     UTC at the start of the day after skip-until): skip (return true).
+//     - Otherwise: do not skip (return false).
+//  3. No relevant annotations present → do not skip (return false).
+//
+// now is passed as a parameter (not time.Now()) so that tests can use a fixed
+// clock without monkey-patching.
+func ShouldSkip(annotations map[string]string, now time.Time) bool {
+	if annotations[AnnotationEnabled] == "false" {
+		return true
+	}
+	if raw, ok := annotations[AnnotationSkipUntil]; ok {
+		t, err := time.Parse("2006-01-02", raw)
+		if err != nil {
+			return false
+		}
+		deadline := t.UTC().AddDate(0, 0, 1)
+		return now.UTC().Before(deadline)
+	}
+	return false
+}

--- a/internal/domain/annotations_test.go
+++ b/internal/domain/annotations_test.go
@@ -1,0 +1,75 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestShouldSkip(t *testing.T) {
+	anyTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		now         time.Time
+		want        bool
+	}{
+		{
+			name:        "SkipWhenDisabled",
+			annotations: map[string]string{AnnotationEnabled: "false"},
+			now:         anyTime,
+			want:        true,
+		},
+		{
+			name:        "SkipWhenSkipUntilInFuture",
+			annotations: map[string]string{AnnotationSkipUntil: "2099-12-31"},
+			now:         time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			want:        true,
+		},
+		{
+			name:        "NoSkipWhenSkipUntilInPast",
+			annotations: map[string]string{AnnotationSkipUntil: "2020-01-01"},
+			now:         time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC),
+			want:        false,
+		},
+		{
+			name:        "NoSkipWhenSkipUntilMalformed",
+			annotations: map[string]string{AnnotationSkipUntil: "not-a-date"},
+			now:         anyTime,
+			want:        false,
+		},
+		{
+			name:        "NoSkipWhenNoAnnotations",
+			annotations: map[string]string{},
+			now:         anyTime,
+			want:        false,
+		},
+		{
+			name:        "NoSkipWhenNilAnnotations",
+			annotations: nil,
+			now:         anyTime,
+			want:        false,
+		},
+		{
+			name:        "SkipOnTheDateItself",
+			annotations: map[string]string{AnnotationSkipUntil: "2025-06-01"},
+			now:         time.Date(2025, 6, 1, 23, 59, 59, 0, time.UTC),
+			want:        true,
+		},
+		{
+			name:        "NoSkipDayAfter",
+			annotations: map[string]string{AnnotationSkipUntil: "2025-06-01"},
+			now:         time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC),
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ShouldSkip(tt.annotations, tt.now)
+			if got != tt.want {
+				t.Errorf("ShouldSkip(%v, %v) = %v, want %v", tt.annotations, tt.now, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/provider/native/deployment.go
+++ b/internal/provider/native/deployment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -37,6 +38,9 @@ func (p *deploymentProvider) ObjectType() client.Object { return &appsv1.Deploym
 // Returns (nil, nil) if the deployment is healthy.
 // Returns (nil, err) if obj is not a *appsv1.Deployment.
 func (p *deploymentProvider) ExtractFinding(obj client.Object) (*domain.Finding, error) {
+	if domain.ShouldSkip(obj.GetAnnotations(), time.Now()) {
+		return nil, nil
+	}
 	deploy, ok := obj.(*appsv1.Deployment)
 	if !ok {
 		return nil, fmt.Errorf("deploymentProvider: expected *appsv1.Deployment, got %T", obj)

--- a/internal/provider/native/deployment_test.go
+++ b/internal/provider/native/deployment_test.go
@@ -8,6 +8,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/lenaxia/k8s-mendabot/internal/domain"
 )
 
 // int32Ptr is a test helper that returns a pointer to an int32.
@@ -507,5 +509,70 @@ func TestBothConditions_TwoEntries(t *testing.T) {
 	}
 	if len(entries) != 2 {
 		t.Errorf("expected 2 error entries (replica mismatch + Available=False), got %d: %s", len(entries), finding.Errors)
+	}
+}
+
+// TestDeploymentAnnotationEnabled_False: degraded deployment (ReadyReplicas=0, Replicas=3)
+// with mendabot.io/enabled=false → (nil, nil).
+// Uses an unhealthy object to prove the gate fires on an object that would otherwise produce
+// a non-nil finding.
+func TestDeploymentAnnotationEnabled_False(t *testing.T) {
+	s := newTestScheme()
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	p := NewDeploymentProvider(c)
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ann-deploy",
+			Namespace: "default",
+			Annotations: map[string]string{
+				domain.AnnotationEnabled: "false",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(3),
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:      3,
+			ReadyReplicas: 0,
+		},
+	}
+	finding, err := p.ExtractFinding(deploy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if finding != nil {
+		t.Errorf("expected nil finding when annotation enabled=false, got %+v", finding)
+	}
+}
+
+// TestDeploymentAnnotationSkipUntilFuture: degraded deployment with mendabot.io/skip-until=2099-12-31 → (nil, nil).
+func TestDeploymentAnnotationSkipUntilFuture(t *testing.T) {
+	s := newTestScheme()
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	p := NewDeploymentProvider(c)
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "skip-deploy",
+			Namespace: "default",
+			Annotations: map[string]string{
+				domain.AnnotationSkipUntil: "2099-12-31",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(3),
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:      3,
+			ReadyReplicas: 0,
+		},
+	}
+	finding, err := p.ExtractFinding(deploy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if finding != nil {
+		t.Errorf("expected nil finding when skip-until is in the future, got %+v", finding)
 	}
 }

--- a/internal/provider/native/job.go
+++ b/internal/provider/native/job.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -38,6 +39,9 @@ func (p *jobProvider) ObjectType() client.Object { return &batchv1.Job{} }
 // or owned by a CronJob.
 // Returns (nil, err) if obj is not a *batchv1.Job.
 func (p *jobProvider) ExtractFinding(obj client.Object) (*domain.Finding, error) {
+	if domain.ShouldSkip(obj.GetAnnotations(), time.Now()) {
+		return nil, nil
+	}
 	job, ok := obj.(*batchv1.Job)
 	if !ok {
 		return nil, fmt.Errorf("jobProvider: expected *batchv1.Job, got %T", obj)

--- a/internal/provider/native/job_test.go
+++ b/internal/provider/native/job_test.go
@@ -10,6 +10,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/lenaxia/k8s-mendabot/internal/domain"
 )
 
 // newExhaustedJob returns a Job in the backoff-exhausted state:
@@ -425,6 +427,46 @@ func TestJobProvider_ExtractFinding_ExcludesMendabotManagedJobs(t *testing.T) {
 	}
 	if finding == nil {
 		t.Fatal("unmanaged job: expected non-nil finding, got nil")
+	}
+}
+
+// TestJobAnnotationEnabled_False: exhausted job (BackoffLimitExceeded) with mendabot.io/enabled=false → (nil, nil).
+// Uses an unhealthy object to prove the gate fires on an object that would otherwise produce
+// a non-nil finding.
+func TestJobAnnotationEnabled_False(t *testing.T) {
+	s := newTestScheme()
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	p := NewJobProvider(c)
+
+	job := newExhaustedJob("ann-job", "default", 3)
+	job.Annotations = map[string]string{
+		domain.AnnotationEnabled: "false",
+	}
+	finding, err := p.ExtractFinding(job)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if finding != nil {
+		t.Errorf("expected nil finding when annotation enabled=false, got %+v", finding)
+	}
+}
+
+// TestJobAnnotationSkipUntilFuture: exhausted job with mendabot.io/skip-until=2099-12-31 → (nil, nil).
+func TestJobAnnotationSkipUntilFuture(t *testing.T) {
+	s := newTestScheme()
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	p := NewJobProvider(c)
+
+	job := newExhaustedJob("skip-job", "default", 3)
+	job.Annotations = map[string]string{
+		domain.AnnotationSkipUntil: "2099-12-31",
+	}
+	finding, err := p.ExtractFinding(job)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if finding != nil {
+		t.Errorf("expected nil finding when skip-until is in the future, got %+v", finding)
 	}
 }
 

--- a/internal/provider/native/node.go
+++ b/internal/provider/native/node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,6 +52,9 @@ func (n *nodeProvider) ObjectType() client.Object { return &corev1.Node{} }
 //
 // EtcdIsVoter (k3s) is explicitly ignored even when True.
 func (n *nodeProvider) ExtractFinding(obj client.Object) (*domain.Finding, error) {
+	if domain.ShouldSkip(obj.GetAnnotations(), time.Now()) {
+		return nil, nil
+	}
 	node, ok := obj.(*corev1.Node)
 	if !ok {
 		return nil, fmt.Errorf("nodeProvider: expected *corev1.Node, got %T", obj)

--- a/internal/provider/native/node_test.go
+++ b/internal/provider/native/node_test.go
@@ -7,6 +7,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/lenaxia/k8s-mendabot/internal/domain"
 )
 
 // healthyNode builds a Node in a fully healthy state:
@@ -512,6 +514,58 @@ func assertNodeErrorTextContains(t *testing.T, errors, substr string) {
 		}
 	}
 	t.Errorf("no error entry contains %q in: %s", substr, errors)
+}
+
+// TestNodeAnnotationEnabled_False: NotReady node with mendabot.io/enabled=false → (nil, nil).
+// Uses an unhealthy object to prove the gate fires on an object that would otherwise produce
+// a non-nil finding.
+func TestNodeAnnotationEnabled_False(t *testing.T) {
+	s := newTestScheme()
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	p := NewNodeProvider(c)
+
+	node := healthyNode("ann-node")
+	node.Annotations = map[string]string{
+		domain.AnnotationEnabled: "false",
+	}
+	node.Status.Conditions[0] = corev1.NodeCondition{
+		Type:    corev1.NodeReady,
+		Status:  corev1.ConditionFalse,
+		Reason:  "KubeletNotReady",
+		Message: "container runtime not ready",
+	}
+	finding, err := p.ExtractFinding(node)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if finding != nil {
+		t.Errorf("expected nil finding when annotation enabled=false, got %+v", finding)
+	}
+}
+
+// TestNodeAnnotationSkipUntilFuture: NotReady node with mendabot.io/skip-until=2099-12-31 → (nil, nil).
+func TestNodeAnnotationSkipUntilFuture(t *testing.T) {
+	s := newTestScheme()
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	p := NewNodeProvider(c)
+
+	node := healthyNode("skip-node")
+	node.Annotations = map[string]string{
+		domain.AnnotationSkipUntil: "2099-12-31",
+	}
+	node.Status.Conditions[0] = corev1.NodeCondition{
+		Type:    corev1.NodeReady,
+		Status:  corev1.ConditionFalse,
+		Reason:  "KubeletNotReady",
+		Message: "container runtime not ready",
+	}
+	finding, err := p.ExtractFinding(node)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if finding != nil {
+		t.Errorf("expected nil finding when skip-until is in the future, got %+v", finding)
+	}
 }
 
 // filterNodeConditions returns conditions excluding all entries of the given type.

--- a/internal/provider/native/pod.go
+++ b/internal/provider/native/pod.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,6 +48,9 @@ func (p *podProvider) ObjectType() client.Object { return &corev1.Pod{} }
 // Returns (nil, nil) if the pod is healthy (no failure conditions detected).
 // Returns (nil, err) if obj is not a *corev1.Pod.
 func (p *podProvider) ExtractFinding(obj client.Object) (*domain.Finding, error) {
+	if domain.ShouldSkip(obj.GetAnnotations(), time.Now()) {
+		return nil, nil
+	}
 	pod, ok := obj.(*corev1.Pod)
 	if !ok {
 		return nil, fmt.Errorf("podProvider: expected *corev1.Pod, got %T", obj)

--- a/internal/provider/native/pod_test.go
+++ b/internal/provider/native/pod_test.go
@@ -10,6 +10,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/lenaxia/k8s-mendabot/internal/domain"
 )
 
 // runningPod returns a healthy running pod with all containers ready.
@@ -823,6 +825,84 @@ func TestUnschedulableMessageRedacted(t *testing.T) {
 		t.Errorf("error text should not contain raw secret value 'supersecrettoken123': %s", finding.Errors)
 	}
 	assertErrorTextContains(t, finding.Errors, "[REDACTED]")
+}
+
+// TestPodAnnotationEnabled_False: crashing pod with mendabot.io/enabled=false → (nil, nil).
+// Uses an unhealthy CrashLoopBackOff pod to prove the gate fires on an object that would
+// otherwise produce a non-nil finding.
+func TestPodAnnotationEnabled_False(t *testing.T) {
+	s := newTestScheme()
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	p := NewPodProvider(c)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ann-pod",
+			Namespace: "default",
+			UID:       "ann-pod-uid",
+			Annotations: map[string]string{
+				domain.AnnotationEnabled: "false",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "my-app",
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason: "CrashLoopBackOff",
+						},
+					},
+				},
+			},
+		},
+	}
+	finding, err := p.ExtractFinding(pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if finding != nil {
+		t.Errorf("expected nil finding when annotation enabled=false, got %+v", finding)
+	}
+}
+
+// TestPodAnnotationSkipUntilFuture: crashing pod with mendabot.io/skip-until=2099-12-31 → (nil, nil).
+func TestPodAnnotationSkipUntilFuture(t *testing.T) {
+	s := newTestScheme()
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	p := NewPodProvider(c)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "skip-pod",
+			Namespace: "default",
+			UID:       "skip-pod-uid",
+			Annotations: map[string]string{
+				domain.AnnotationSkipUntil: "2099-12-31",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "my-app",
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason: "CrashLoopBackOff",
+						},
+					},
+				},
+			},
+		},
+	}
+	finding, err := p.ExtractFinding(pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if finding != nil {
+		t.Errorf("expected nil finding when skip-until is in the future, got %+v", finding)
+	}
 }
 
 // assertErrorsJSON verifies that the errors string is valid JSON with at least one entry.

--- a/internal/provider/native/pvc.go
+++ b/internal/provider/native/pvc.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,6 +38,9 @@ func (p *pvcProvider) ObjectType() client.Object { return &corev1.PersistentVolu
 // Returns (nil, nil) if the PVC is not Pending, or if Pending but has no ProvisioningFailed event.
 // Returns (nil, err) if obj is not a *corev1.PersistentVolumeClaim.
 func (p *pvcProvider) ExtractFinding(obj client.Object) (*domain.Finding, error) {
+	if domain.ShouldSkip(obj.GetAnnotations(), time.Now()) {
+		return nil, nil
+	}
 	pvc, ok := obj.(*corev1.PersistentVolumeClaim)
 	if !ok {
 		return nil, fmt.Errorf("pvcProvider: expected *corev1.PersistentVolumeClaim, got %T", obj)

--- a/internal/provider/native/pvc_test.go
+++ b/internal/provider/native/pvc_test.go
@@ -7,6 +7,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/lenaxia/k8s-mendabot/internal/domain"
 )
 
 // makePVC builds a PVC with the given name, namespace and phase.
@@ -253,6 +255,50 @@ func TestPVCEventMessageRedacted(t *testing.T) {
 		t.Errorf("error text should not contain raw secret value 'secret123': %s", finding.Errors)
 	}
 	assertErrorTextContains(t, finding.Errors, "[REDACTED]")
+}
+
+// TestPVCAnnotationEnabled_False: Pending PVC with ProvisioningFailed event and mendabot.io/enabled=false → (nil, nil).
+// Uses an unhealthy object to prove the gate fires on an object that would otherwise produce
+// a non-nil finding.
+func TestPVCAnnotationEnabled_False(t *testing.T) {
+	s := newTestScheme()
+	pvc := makePVC("ann-pvc", "default", corev1.ClaimPending)
+	pvc.Annotations = map[string]string{
+		domain.AnnotationEnabled: "false",
+	}
+	event := makeEvent("ann-pvc", "default", "ProvisioningFailed", "no storage class found")
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pvc, event).Build()
+	p := NewPVCProvider(c)
+
+	finding, err := p.ExtractFinding(pvc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if finding != nil {
+		t.Errorf("expected nil finding when annotation enabled=false, got %+v", finding)
+	}
+}
+
+// TestPVCAnnotationSkipUntilFuture: Pending PVC with ProvisioningFailed event and mendabot.io/skip-until=2099-12-31 → (nil, nil).
+func TestPVCAnnotationSkipUntilFuture(t *testing.T) {
+	s := newTestScheme()
+	pvc := makePVC("skip-pvc", "default", corev1.ClaimPending)
+	pvc.Annotations = map[string]string{
+		domain.AnnotationSkipUntil: "2099-12-31",
+	}
+	event := makeEvent("skip-pvc", "default", "ProvisioningFailed", "no storage class found")
+
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(pvc, event).Build()
+	p := NewPVCProvider(c)
+
+	finding, err := p.ExtractFinding(pvc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if finding != nil {
+		t.Errorf("expected nil finding when skip-until is in the future, got %+v", finding)
+	}
 }
 
 // TestPVCEventForDifferentKind_ReturnsNil: Pending PVC, but event's involvedObject.kind

--- a/internal/provider/native/statefulset.go
+++ b/internal/provider/native/statefulset.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -37,6 +38,9 @@ func (p *statefulSetProvider) ObjectType() client.Object { return &appsv1.Statef
 // Returns (nil, nil) if the statefulset is healthy.
 // Returns (nil, err) if obj is not a *appsv1.StatefulSet.
 func (p *statefulSetProvider) ExtractFinding(obj client.Object) (*domain.Finding, error) {
+	if domain.ShouldSkip(obj.GetAnnotations(), time.Now()) {
+		return nil, nil
+	}
 	sts, ok := obj.(*appsv1.StatefulSet)
 	if !ok {
 		return nil, fmt.Errorf("statefulSetProvider: expected *appsv1.StatefulSet, got %T", obj)

--- a/internal/provider/native/statefulset_test.go
+++ b/internal/provider/native/statefulset_test.go
@@ -8,6 +8,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/lenaxia/k8s-mendabot/internal/domain"
 )
 
 // TestStatefulSetProviderName_IsNative verifies ProviderName() returns "native".
@@ -430,6 +432,74 @@ func TestStatefulSetBothConditions_TwoEntries(t *testing.T) {
 	}
 	if len(entries) != 2 {
 		t.Errorf("expected 2 error entries (replica mismatch + Available=False), got %d: %s", len(entries), finding.Errors)
+	}
+}
+
+// TestStatefulSetAnnotationEnabled_False: degraded statefulset (ReadyReplicas=0, Replicas=3)
+// with mendabot.io/enabled=false → (nil, nil).
+// Uses an unhealthy object to prove the gate fires on an object that would otherwise produce
+// a non-nil finding.
+func TestStatefulSetAnnotationEnabled_False(t *testing.T) {
+	s := newTestScheme()
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	p := NewStatefulSetProvider(c)
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "ann-sts",
+			Namespace:  "default",
+			Generation: 1,
+			Annotations: map[string]string{
+				domain.AnnotationEnabled: "false",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: int32Ptr(3),
+		},
+		Status: appsv1.StatefulSetStatus{
+			ObservedGeneration: 1,
+			Replicas:           3,
+			ReadyReplicas:      0,
+		},
+	}
+	finding, err := p.ExtractFinding(sts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if finding != nil {
+		t.Errorf("expected nil finding when annotation enabled=false, got %+v", finding)
+	}
+}
+
+// TestStatefulSetAnnotationSkipUntilFuture: degraded statefulset with mendabot.io/skip-until=2099-12-31 → (nil, nil).
+func TestStatefulSetAnnotationSkipUntilFuture(t *testing.T) {
+	s := newTestScheme()
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+	p := NewStatefulSetProvider(c)
+
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "skip-sts",
+			Namespace:  "default",
+			Generation: 1,
+			Annotations: map[string]string{
+				domain.AnnotationSkipUntil: "2099-12-31",
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: int32Ptr(3),
+		},
+		Status: appsv1.StatefulSetStatus{
+			ObservedGeneration: 1,
+			ReadyReplicas:      0,
+		},
+	}
+	finding, err := p.ExtractFinding(sts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if finding != nil {
+		t.Errorf("expected nil finding when skip-until is in the future, got %+v", finding)
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -170,7 +170,8 @@ func (r *SourceProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, fmt.Errorf("fingerprint too short: got %d chars, need at least 12", len(fp))
 	}
 
-	if r.Cfg.StabilisationWindow != 0 {
+	priorityCritical := obj.GetAnnotations()[domain.AnnotationPriority] == "critical"
+	if !priorityCritical && r.Cfg.StabilisationWindow != 0 {
 		if first, seen := r.firstSeen.Get(fp); !seen {
 			r.firstSeen.Set(fp)
 			if r.Log != nil {
@@ -192,9 +193,6 @@ func (r *SourceProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				}
 				return ctrl.Result{RequeueAfter: remaining}, nil
 			}
-			// Window has elapsed — fall through to dedup + Job creation.
-			// Leave the firstSeen entry so repeated reconciles after Job creation
-			// do not restart the window.
 		}
 	}
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lenaxia/k8s-mendabot/internal/config"
 	"github.com/lenaxia/k8s-mendabot/internal/domain"
 	"github.com/lenaxia/k8s-mendabot/internal/provider"
+	"github.com/lenaxia/k8s-mendabot/internal/provider/native"
 )
 
 // fakeSourceProvider is a controllable domain.SourceProvider for unit tests.
@@ -1226,6 +1227,90 @@ func TestReconcile_ReadinessGate_NilChecker_AllowsJobCreation(t *testing.T) {
 	}
 }
 
+// makeWatchedObjectWithAnnotations creates a ConfigMap with the given annotations as the
+// watched object. Used by priority bypass tests.
+func makeWatchedObjectWithAnnotations(name, namespace string, annotations map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+	}
+}
+
+// TestStabilisationWindow_PriorityCriticalBypassesWindow verifies that when the reconciled
+// resource carries annotation mendabot.io/priority=critical and StabilisationWindow > 0,
+// the stabilisation window is bypassed: a RemediationJob is created immediately, no
+// RequeueAfter is returned, and firstSeen is never touched.
+func TestStabilisationWindow_PriorityCriticalBypassesWindow(t *testing.T) {
+	finding := makeFinding()
+	p := &fakeSourceProvider{
+		name:       "native",
+		objectType: &corev1.ConfigMap{},
+		finding:    finding,
+	}
+	obj := makeWatchedObjectWithAnnotations("r1", "default", map[string]string{
+		domain.AnnotationPriority: "critical",
+	})
+	c := newTestClient(obj)
+	window := 2 * time.Minute
+	r := newTestReconcilerWithWindow(p, c, window)
+
+	result, err := r.Reconcile(context.Background(), reqFor("r1", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Errorf("expected no RequeueAfter for critical priority, got %v", result.RequeueAfter)
+	}
+
+	var list v1alpha1.RemediationJobList
+	if err := c.List(context.Background(), &list, client.InNamespace(agentNamespace)); err != nil {
+		t.Fatalf("list error: %v", err)
+	}
+	if len(list.Items) != 1 {
+		t.Errorf("expected 1 RemediationJob created immediately for critical priority, got %d", len(list.Items))
+	}
+
+	if len(r.FirstSeen()) != 0 {
+		t.Errorf("expected firstSeen to remain empty for critical priority, got %d entries", len(r.FirstSeen()))
+	}
+}
+
+// TestStabilisationWindow_PriorityCriticalWindowAlreadyZero verifies that when
+// StabilisationWindow==0 and the resource has annotation mendabot.io/priority=critical,
+// a RemediationJob is still created immediately (same as the fast path without annotation).
+func TestStabilisationWindow_PriorityCriticalWindowAlreadyZero(t *testing.T) {
+	finding := makeFinding()
+	p := &fakeSourceProvider{
+		name:       "native",
+		objectType: &corev1.ConfigMap{},
+		finding:    finding,
+	}
+	obj := makeWatchedObjectWithAnnotations("r1", "default", map[string]string{
+		domain.AnnotationPriority: "critical",
+	})
+	c := newTestClient(obj)
+	r := newTestReconcilerWithWindow(p, c, 0)
+
+	result, err := r.Reconcile(context.Background(), reqFor("r1", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Errorf("expected no RequeueAfter for window=0 with critical priority, got %v", result.RequeueAfter)
+	}
+
+	var list v1alpha1.RemediationJobList
+	if err := c.List(context.Background(), &list, client.InNamespace(agentNamespace)); err != nil {
+		t.Fatalf("list error: %v", err)
+	}
+	if len(list.Items) != 1 {
+		t.Errorf("expected 1 RemediationJob created immediately for window=0 with critical priority, got %d", len(list.Items))
+	}
+}
+
 // TestReconcile_EventRecorder_EmitsRemediationJobCreated verifies that when an
 // EventRecorder is wired and a RemediationJob is successfully created, a Normal
 // "RemediationJobCreated" Kubernetes Event is emitted on the source object.
@@ -1271,5 +1356,65 @@ func TestReconcile_EventRecorder_EmitsRemediationJobCreated(t *testing.T) {
 	}
 	if !strings.Contains(event, string(corev1.EventTypeNormal)) {
 		t.Errorf("expected Normal event type, got: %q", event)
+	}
+}
+
+// TestAnnotationGate_EnabledFalse_NoRemediationJob is an integration test that uses a real
+// podProvider (from internal/provider/native) as the SourceProvider. It creates a failing Pod
+// (CrashLoopBackOff) with mendabot.io/enabled="false" in the fake client, runs
+// SourceProviderReconciler.Reconcile, and asserts that zero RemediationJob objects are created.
+func TestAnnotationGate_EnabledFalse_NoRemediationJob(t *testing.T) {
+	s := newTestScheme()
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithStatusSubresource(&v1alpha1.RemediationJob{}).
+		Build()
+
+	podProvider := native.NewPodProvider(c)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "crash-pod",
+			Namespace: "default",
+			Annotations: map[string]string{
+				domain.AnnotationEnabled: "false",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "my-app",
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason: "CrashLoopBackOff",
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := c.Create(context.Background(), pod); err != nil {
+		t.Fatalf("creating pod: %v", err)
+	}
+
+	r := &provider.SourceProviderReconciler{
+		Client:   c,
+		Scheme:   s,
+		Cfg:      config.Config{AgentNamespace: agentNamespace},
+		Provider: podProvider,
+	}
+
+	_, err := r.Reconcile(context.Background(), reqFor("crash-pod", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var list v1alpha1.RemediationJobList
+	if err := c.List(context.Background(), &list, client.InNamespace(agentNamespace)); err != nil {
+		t.Fatalf("list error: %v", err)
+	}
+	if len(list.Items) != 0 {
+		t.Errorf("expected 0 RemediationJobs when annotation enabled=false on a failing pod, got %d", len(list.Items))
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `mendabot.io/enabled: "false"` annotation support — suppresses all investigations for a resource permanently
- Adds `mendabot.io/skip-until: "YYYY-MM-DD"` annotation support — suppresses investigations until the end of the given date (inclusive, midnight UTC)
- Adds `mendabot.io/priority: "critical"` annotation support — bypasses the stabilisation window for immediate investigation

## Changes

### `internal/domain/annotations.go` (new)
Three typed constants (`AnnotationEnabled`, `AnnotationSkipUntil`, `AnnotationPriority`) and `ShouldSkip(annotations map[string]string, now time.Time) bool` helper. Pure domain logic, no external imports beyond `time`.

### All 6 native providers (`pod`, `deployment`, `statefulset`, `job`, `node`, `pvc`)
`domain.ShouldSkip(obj.GetAnnotations(), time.Now())` added as the **first statement** in each `ExtractFinding`, before any type assertion. Returns `(nil, nil)` when suppression is active.

### `internal/provider/provider.go`
`priorityCritical := obj.GetAnnotations()[domain.AnnotationPriority] == "critical"` guard wraps the stabilisation window block. When `priority=critical`, `firstSeen` is never consulted and no requeue is issued — execution falls through directly to dedup + RemediationJob creation.

## Tests

- 8 unit tests for `ShouldSkip` (boundary cases, nil map, malformed date)
- 2 annotation tests per provider (12 total) using **unhealthy** objects that prove the gate fires
- 2 unit tests for priority bypass in reconciler
- 1 e2e integration test: real `podProvider` + annotated CrashLoopBackOff pod + reconciler → zero RemediationJobs

All 12 packages pass `go test -timeout 60s -race -count=1 ./...`, race detector clean.

## Closes

Epic 16 (FT-A2) — all 3 stories complete.