### PR TITLE
feat(epic26): auto-close resolved findings via GitHub REST API (v0.3.25)

### DIFF
--- a/api/v1alpha1/remediationjob_types.go
+++ b/api/v1alpha1/remediationjob_types.go
@@ -189,6 +189,22 @@ type FindingSpec struct {
 	ChainDepth int32 `json:"chainDepth,omitempty"`
 }
 
+// SinkRef identifies the GitHub PR or issue opened by the agent.
+// Set by the agent via a status patch after gh pr create succeeds.
+// Used by the watcher to auto-close the sink when the finding resolves.
+type SinkRef struct {
+	// Type is "pr" or "issue".
+	Type string `json:"type"`
+	// URL is the full HTML URL (e.g. https://github.com/org/repo/pull/42).
+	// Used in log messages and closure comments.
+	URL string `json:"url"`
+	// Number is the PR or issue number. Required for GitHub REST API calls.
+	Number int `json:"number"`
+	// Repo is "owner/repo" format (e.g. "lenaxia/talos-ops-prod").
+	// Required for GitHub REST API calls.
+	Repo string `json:"repo"`
+}
+
 // RemediationJobStatus defines the observed state of a RemediationJob.
 type RemediationJobStatus struct {
 	// Phase is the current lifecycle phase of this RemediationJob.
@@ -235,6 +251,11 @@ type RemediationJobStatus struct {
 	// (controller.go) reconstructs AllFindings from suppressed peers on restart.
 	// CorrelationGroupID here is the only status field needed for recovery.
 	CorrelationGroupID string `json:"correlationGroupID,omitempty"`
+
+	// SinkRef identifies the GitHub PR or issue opened by the agent.
+	// Empty until the agent writes it after opening the sink.
+	// +optional
+	SinkRef SinkRef `json:"sinkRef,omitempty"`
 }
 
 // RemediationJob represents one investigation and remediation attempt for a
@@ -285,6 +306,8 @@ func (in *RemediationJob) DeepCopyInto(out *RemediationJob) {
 		out.Status.Conditions = conditions
 	}
 	out.Status.CorrelationGroupID = in.Status.CorrelationGroupID
+	// SinkRef contains only value types (string, int); shallow copy is correct.
+	out.Status.SinkRef = in.Status.SinkRef
 }
 
 // DeepCopyObject implements runtime.Object.

--- a/charts/mendabot/Chart.yaml
+++ b/charts/mendabot/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mendabot
 description: Kubernetes-native SRE remediation bot — watches cluster failures, spawns an LLM agent, and opens GitOps pull requests with proposed fixes.
 type: application
-version: 0.3.23
-appVersion: v0.3.23
+version: 0.3.25
+appVersion: v0.3.25
 kubeVersion: ">=1.28.0-0"
 keywords:
   - kubernetes
@@ -25,16 +25,14 @@ annotations:
     fingerprint: ""
     url: https://github.com/lenaxia.gpg
   artifacthub.io/changes: |
-    - kind: security
-      description: "Tool call output redaction wrappers (epic25) — all kubectl/helm/flux/gh output piped through domain.RedactSecrets before reaching LLM API (P-010 HIGH remediated)"
-    - kind: security
-      description: "Agent ClusterRole wildcard replaced with explicit resource enumeration, removing nodes/proxy access (P-004 HIGH remediated)"
-    - kind: security
-      description: "DetectInjection added to RemediationJobController dispatch path (P-008 MEDIUM remediated)"
-    - kind: security
-      description: "PEM key header and X-API-Key redaction patterns added"
-    - kind: fixed
-      description: "FINDING_FINGERPRINT truncated to 12 chars to prevent base64 redaction false positive"
+    - kind: added
+      description: "Auto-close resolved findings (epic26) — watcher closes GitHub PRs via REST API when the underlying Kubernetes issue self-heals"
+    - kind: added
+      description: "GitHub App token provider in watcher (55-min cache, RS256 JWT exchange)"
+    - kind: added
+      description: "SinkRef status field on RemediationJob — structured PR/issue reference used by auto-close"
+    - kind: added
+      description: "Agent STEP 9 — writes SinkRef back to RemediationJob status after opening a PR"
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/recommendations: |
     - url: https://artifacthub.io/packages/helm/cert-manager/cert-manager

--- a/charts/mendabot/README.md
+++ b/charts/mendabot/README.md
@@ -1,6 +1,6 @@
 # mendabot
 
-![Version: 0.3.13](https://img.shields.io/badge/Version-0.3.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.13](https://img.shields.io/badge/AppVersion-v0.3.13-informational?style=flat-square)
+![Version: 0.3.25](https://img.shields.io/badge/Version-0.3.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.25](https://img.shields.io/badge/AppVersion-v0.3.25-informational?style=flat-square)
 
 Kubernetes-native SRE remediation bot — watches cluster failures, spawns an LLM agent, and opens GitOps pull requests with proposed fixes.
 
@@ -90,14 +90,27 @@ kubectl delete crd remediationjobs.remediation.mendabot.io
 | prompt.coreOverride | string | `""` | Full core prompt content override. When non-empty, replaces the built-in core prompt mounted from the ConfigMap. |
 | rbac.create | bool | `true` | Create RBAC resources. Set to `false` if you manage RBAC externally. |
 | secrets | object | `{}` | Pre-existing Secrets that must be created before `helm install`. The chart never creates Secret content. Secret names are derived from `agentType` at runtime: `llm-credentials-<agentType>`. Required Secrets: `github-app` (keys: `app-id`, `installation-id`, `private-key`), `llm-credentials-opencode` (key: `provider-config`). |
+| selfRemediation | object | `{"cascadeNamespaceThreshold":50,"cascadeNodeCacheTTLSeconds":30,"cooldownSeconds":300,"disableCascadeCheck":false,"disableUpstreamContributions":false,"maxDepth":2,"upstreamRepo":""}` | Self-remediation configuration. |
+| selfRemediation.cascadeNamespaceThreshold | int | `50` | Cascade namespace threshold. Default is 50. |
+| selfRemediation.cascadeNodeCacheTTLSeconds | int | `30` | Cascade node cache TTL in seconds. Default is 30. |
+| selfRemediation.cooldownSeconds | int | `300` | Minimum time between allowed self-remediations. 0 disables circuit breaker.    Default is 300 (5 minutes). |
+| selfRemediation.disableCascadeCheck | bool | `false` | Disable cascade check. Default is false. |
+| selfRemediation.disableUpstreamContributions | bool | `false` | Disable upstream contributions (legacy, unused in current codebase). |
+| selfRemediation.maxDepth | int | `2` | Maximum self-remediation chain depth. Findings with ChainDepth > maxDepth are suppressed.    0 disables self-remediation entirely. Default is 2. |
+| selfRemediation.upstreamRepo | string | `""` | Upstream repository for contributions (legacy, unused in current codebase). |
 | watcher.agentRBACScope | string | `"cluster"` | RBAC scope for the agent Job. One of `"cluster"` (default) or `"namespace"`. When `"namespace"`, `agentWatchNamespaces` must also be set. |
 | watcher.agentWatchNamespaces | string | `""` | Comma-separated list of namespaces for namespace-scoped agent RBAC. Required when `agentRBACScope=namespace`. Example: `"production,staging"`. |
+| watcher.correlationWindowSeconds | int | `30` | Seconds to hold Pending jobs before dispatching (correlation window). Set to 0 to    dispatch immediately without correlation. Default is 30. |
+| watcher.disableCorrelation | bool | `false` | Disable all correlation logic and dispatch immediately. Default is false. |
+| watcher.dryRun | bool | `false` | Enable dry-run shadow mode. When true, write operations are blocked and investigation reports are stored in RemediationJob.status.message. |
 | watcher.excludeNamespaces | string | `""` | Comma-separated list of namespaces the watcher ignores. Empty means no exclusions. Example: `"kube-system,monitoring"`. |
 | watcher.injectionDetectionAction | string | `"log"` | Action when a prompt injection heuristic fires. One of `"log"` (default) or `"suppress"` (silently drops the finding). |
 | watcher.llmProvider | string | `"openai"` | LLM readiness gate. Set to `"openai"` to block RemediationJob creation until the `llm-credentials-<agentType>` Secret exists. Leave empty to disable. |
 | watcher.logLevel | string | `"info"` | Zap log level. One of `debug`, `info`, `warn`, `error`. |
 | watcher.maxConcurrentJobs | int | `3` | Maximum number of agent Jobs running concurrently. |
 | watcher.maxInvestigationRetries | string | `"3"` | Maximum number of investigation retries per RemediationJob before permanently failing. |
+| watcher.multiPodThreshold | int | `3` | Minimum number of pods failing on the same node to trigger MultiPodSameNodeRule.    Default is 3. |
+| watcher.prAutoClose | bool | `true` | Automatically close open GitHub PRs/issues when the underlying finding resolves.    Set to false to disable auto-close and leave PRs open for manual review. |
 | watcher.remediationJobTTLSeconds | int | `604800` | Time-to-live for completed RemediationJob objects in seconds. Default is 7 days. |
 | watcher.sinkType | string | `"github"` | Sink type for PR creation. Currently only `"github"` is supported. |
 | watcher.stabilisationWindowSeconds | int | `120` | Seconds to wait after first detecting a failure before creating a RemediationJob. Set to `0` to dispatch immediately. |

--- a/charts/mendabot/crds/remediation.mendabot.io_remediationjobs.yaml
+++ b/charts/mendabot/crds/remediation.mendabot.io_remediationjobs.yaml
@@ -309,6 +309,34 @@ spec:
                   whether to re-dispatch or tombstone.
                 format: int32
                 type: integer
+              sinkRef:
+                description: |-
+                  SinkRef identifies the GitHub PR or issue opened by the agent.
+                  Empty until the agent writes it after opening the sink.
+                properties:
+                  number:
+                    description: Number is the PR or issue number. Required for GitHub
+                      REST API calls.
+                    type: integer
+                  repo:
+                    description: |-
+                      Repo is "owner/repo" format (e.g. "lenaxia/talos-ops-prod").
+                      Required for GitHub REST API calls.
+                    type: string
+                  type:
+                    description: Type is "pr" or "issue".
+                    type: string
+                  url:
+                    description: |-
+                      URL is the full HTML URL (e.g. https://github.com/org/repo/pull/42).
+                      Used in log messages and closure comments.
+                    type: string
+                required:
+                - number
+                - repo
+                - type
+                - url
+                type: object
             type: object
         required:
         - spec

--- a/charts/mendabot/files/prompts/core.txt
+++ b/charts/mendabot/files/prompts/core.txt
@@ -218,6 +218,57 @@ ${FINDING_CORRELATED_FINDINGS}
 ---
 *Opened automatically by mendabot*
 
+STEP 9 — Write SinkRef back to the RemediationJob (MANDATORY)
+
+After STEP 8 completes — whether a new PR was opened or an existing PR was found and
+commented on in STEP 1 — write the PR reference back to the RemediationJob status
+subresource. This enables the watcher to auto-close the PR when the underlying issue
+resolves.
+
+RJOB_NAME="mendabot-${FINDING_FINGERPRINT:0:12}"
+RJOB_NAMESPACE="${AGENT_NAMESPACE}"
+
+Capture PR_URL and PR_NUMBER:
+
+  If you opened a NEW PR in STEP 8 using --json url,number:
+    PR_URL=$(echo "$PR_OUTPUT" | jq -r '.url')
+    PR_NUMBER=$(echo "$PR_OUTPUT" | jq -r '.number')
+
+  If you found an EXISTING PR in STEP 1:
+    PR_URL=$(gh pr view --repo ${GITOPS_REPO} fix/mendabot-${FINDING_FINGERPRINT} --json url -q .url)
+    PR_NUMBER=$(gh pr view --repo ${GITOPS_REPO} fix/mendabot-${FINDING_FINGERPRINT} --json number -q .number)
+
+PR_REPO="${GITOPS_REPO}"
+
+kubectl patch remediationjob "${RJOB_NAME}" \
+  --namespace "${RJOB_NAMESPACE}" \
+  --subresource=status \
+  --type=merge \
+  --patch "{
+    \"status\": {
+      \"prRef\": \"${PR_URL}\",
+      \"sinkRef\": {
+        \"type\": \"pr\",
+        \"url\": \"${PR_URL}\",
+        \"number\": ${PR_NUMBER},
+        \"repo\": \"${PR_REPO}\"
+      }
+    }
+  }" || echo "WARNING: failed to write SinkRef to RemediationJob — PR is still open and valid"
+
+If the kubectl patch fails, print the warning and continue. The PR is already open and
+must not be retracted. The auto-close feature will not work for this run, but the
+investigation result is preserved.
+
+NOTE: gh pr create must be called with --json url,number to capture output:
+  PR_OUTPUT=$(gh pr create \
+    --repo ${GITOPS_REPO} \
+    --base main \
+    --head fix/mendabot-${FINDING_FINGERPRINT} \
+    --title "..." \
+    --body "..." \
+    --json url,number)
+
 === HARD RULES ===
 
 These are non-negotiable. Violating any of them is an error.

--- a/charts/mendabot/files/prompts/core.txt
+++ b/charts/mendabot/files/prompts/core.txt
@@ -167,12 +167,16 @@ STEP 8 — Open a pull request
   git -C /workspace/repo commit -m "fix(${FINDING_KIND}/${FINDING_PARENT}): <concise description>"
   git -C /workspace/repo push origin fix/mendabot-${FINDING_FINGERPRINT}
 
-  gh pr create \
+  PR_OUTPUT=$(gh pr create \
     --repo ${GITOPS_REPO} \
     --base main \
     --head fix/mendabot-${FINDING_FINGERPRINT} \
     --title "fix(${FINDING_KIND}/${FINDING_PARENT}): <concise description>" \
-    --body "<see PR body format below>"
+    --body "<see PR body format below>" \
+    --json url,number)
+
+  # PR_OUTPUT now contains JSON: {"url":"https://...","number":42}
+  # This is consumed by STEP 9 to write SinkRef back to the RemediationJob.
 
 === PR BODY FORMAT ===
 
@@ -259,15 +263,6 @@ kubectl patch remediationjob "${RJOB_NAME}" \
 If the kubectl patch fails, print the warning and continue. The PR is already open and
 must not be retracted. The auto-close feature will not work for this run, but the
 investigation result is preserved.
-
-NOTE: gh pr create must be called with --json url,number to capture output:
-  PR_OUTPUT=$(gh pr create \
-    --repo ${GITOPS_REPO} \
-    --base main \
-    --head fix/mendabot-${FINDING_FINGERPRINT} \
-    --title "..." \
-    --body "..." \
-    --json url,number)
 
 === HARD RULES ===
 

--- a/charts/mendabot/templates/NOTES.txt
+++ b/charts/mendabot/templates/NOTES.txt
@@ -21,6 +21,11 @@ via Helm values.
      https://github.com/organizations/<org>/settings/installations/<id>
      (personal: https://github.com/settings/installations/<id>)
 
+   NOTE: The watcher pod also consumes this Secret when watcher.prAutoClose=true
+   (the default). If the Secret is absent the watcher pod will fail with
+   CreateContainerConfigError. To disable this requirement set
+   watcher.prAutoClose=false in your values.yaml.
+
 2. LLM + cluster credentials (Secret name: "llm-credentials-{{ .Values.agentType }}"):
    The Secret uses an opaque config blob pattern — mendabot never interprets
    the provider-config content; it is passed directly to the agent runner.

--- a/charts/mendabot/templates/deployment-watcher.yaml
+++ b/charts/mendabot/templates/deployment-watcher.yaml
@@ -98,9 +98,23 @@ spec:
           value: {{ .Values.selfRemediation.cascadeNodeCacheTTLSeconds | quote }}
         - name: PR_AUTO_CLOSE
           value: {{ .Values.watcher.prAutoClose | quote }}
-        envFrom:
-        - secretRef:
-            name: mendabot-github-app
+        {{- if .Values.watcher.prAutoClose }}
+        - name: GITHUB_APP_ID
+          valueFrom:
+            secretKeyRef:
+              name: github-app
+              key: app-id
+        - name: GITHUB_APP_INSTALLATION_ID
+          valueFrom:
+            secretKeyRef:
+              name: github-app
+              key: installation-id
+        - name: GITHUB_APP_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: github-app
+              key: private-key
+        {{- end }}
         ports:
         - name: metrics
           containerPort: 8080

--- a/charts/mendabot/templates/deployment-watcher.yaml
+++ b/charts/mendabot/templates/deployment-watcher.yaml
@@ -96,6 +96,11 @@ spec:
           value: {{ .Values.selfRemediation.cascadeNamespaceThreshold | quote }}
         - name: CASCADE_NODE_CACHE_TTL_SECONDS
           value: {{ .Values.selfRemediation.cascadeNodeCacheTTLSeconds | quote }}
+        - name: PR_AUTO_CLOSE
+          value: {{ .Values.watcher.prAutoClose | quote }}
+        envFrom:
+        - secretRef:
+            name: mendabot-github-app
         ports:
         - name: metrics
           containerPort: 8080

--- a/charts/mendabot/values.schema.json
+++ b/charts/mendabot/values.schema.json
@@ -100,6 +100,10 @@
           "type": "integer",
           "minimum": 1,
           "description": "Minimum number of pods failing on the same node to trigger MultiPodSameNodeRule."
+        },
+        "prAutoClose": {
+          "type": "boolean",
+          "description": "Automatically close open GitHub PRs/issues when the underlying finding resolves."
         }
       }
     },

--- a/charts/mendabot/values.yaml
+++ b/charts/mendabot/values.yaml
@@ -62,6 +62,9 @@ watcher:
   # -- Minimum number of pods failing on the same node to trigger MultiPodSameNodeRule.
   #    Default is 3.
   multiPodThreshold: 3
+  # -- Automatically close open GitHub PRs/issues when the underlying finding resolves.
+  #    Set to false to disable auto-close and leave PRs open for manual review.
+  prAutoClose: true
 
 # -- Self-remediation configuration.
 selfRemediation:

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -195,7 +195,7 @@ func main() {
 	}
 
 	// Wire GitHub App token provider and sink closer.
-	// envFrom on the Deployment guarantees these vars are present when the pod starts.
+	// secretKeyRef entries on the Deployment (conditional on prAutoClose) guarantee these vars are present when the pod starts.
 	// If PRAutoClose is false, use NoopSinkCloser — no credentials needed.
 	var sinkCloser domain.SinkCloser
 	if cfg.PRAutoClose {

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -17,6 +18,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	gozapr "github.com/go-logr/zapr"
+	"github.com/golang-jwt/jwt/v5"
 	"go.uber.org/zap"
 
 	"github.com/lenaxia/k8s-mendabot/api/v1alpha1"
@@ -25,6 +27,7 @@ import (
 	"github.com/lenaxia/k8s-mendabot/internal/controller"
 	"github.com/lenaxia/k8s-mendabot/internal/correlator"
 	"github.com/lenaxia/k8s-mendabot/internal/domain"
+	igithub "github.com/lenaxia/k8s-mendabot/internal/github"
 	"github.com/lenaxia/k8s-mendabot/internal/jobbuilder"
 	"github.com/lenaxia/k8s-mendabot/internal/logging"
 	"github.com/lenaxia/k8s-mendabot/internal/provider"
@@ -32,6 +35,7 @@ import (
 	"github.com/lenaxia/k8s-mendabot/internal/readiness"
 	"github.com/lenaxia/k8s-mendabot/internal/readiness/llm"
 	"github.com/lenaxia/k8s-mendabot/internal/readiness/sink"
+	sinkhub "github.com/lenaxia/k8s-mendabot/internal/sink/github"
 )
 
 // Version is embedded at build time via ldflags:
@@ -189,6 +193,40 @@ func main() {
 		native.NewStatefulSetProvider(nativeClient),
 		native.NewJobProvider(nativeClient),
 	}
+
+	// Wire GitHub App token provider and sink closer.
+	// envFrom on the Deployment guarantees these vars are present when the pod starts.
+	// If PRAutoClose is false, use NoopSinkCloser — no credentials needed.
+	var sinkCloser domain.SinkCloser
+	if cfg.PRAutoClose {
+		appID, err := strconv.ParseInt(os.Getenv("GITHUB_APP_ID"), 10, 64)
+		if err != nil || appID <= 0 {
+			logger.Fatal("GITHUB_APP_ID is missing or invalid; cannot start with PR_AUTO_CLOSE=true",
+				zap.Error(err))
+		}
+		installID, err := strconv.ParseInt(os.Getenv("GITHUB_APP_INSTALLATION_ID"), 10, 64)
+		if err != nil || installID <= 0 {
+			logger.Fatal("GITHUB_APP_INSTALLATION_ID is missing or invalid; cannot start with PR_AUTO_CLOSE=true",
+				zap.Error(err))
+		}
+		privKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(os.Getenv("GITHUB_APP_PRIVATE_KEY")))
+		if err != nil {
+			logger.Fatal("GITHUB_APP_PRIVATE_KEY is missing or invalid; cannot start with PR_AUTO_CLOSE=true",
+				zap.Error(err))
+		}
+		sinkCloser = &sinkhub.GitHubSinkCloser{
+			TokenProvider: &igithub.GitHubAppTokenProvider{
+				AppID:          appID,
+				InstallationID: installID,
+				PrivateKey:     privKey,
+			},
+		}
+		logger.Info("auto-close sink enabled", zap.Bool("prAutoClose", true))
+	} else {
+		sinkCloser = domain.NoopSinkCloser{}
+		logger.Info("auto-close sink disabled (PR_AUTO_CLOSE=false)")
+	}
+
 	for _, p := range enabledProviders {
 		if err := (&provider.SourceProviderReconciler{
 			Client:           mgr.GetClient(),
@@ -199,6 +237,7 @@ func main() {
 			EventRecorder:    mgr.GetEventRecorderFor("mendabot-watcher"),
 			ReadinessChecker: combinedChecker,
 			CircuitBreaker:   cb,
+			SinkCloser:       sinkCloser,
 		}).SetupWithManager(mgr); err != nil {
 			logger.Fatal("provider setup failed", zap.Error(err))
 		}

--- a/docs/BACKLOG/epic26-auto-close-resolved/README.md
+++ b/docs/BACKLOG/epic26-auto-close-resolved/README.md
@@ -3,16 +3,19 @@
 ## Purpose
 
 When a finding clears — the deployment recovers, the PVC is provisioned, the node
-returns to Ready — the `SourceProviderReconciler` already cancels `Pending` and
-`Dispatched` `RemediationJob` objects. But if the agent opened a PR or a GitHub issue
-before the finding cleared, those sinks remain open indefinitely. A human must manually
-close them. For clusters with frequent transient failures this produces a backlog of
-stale PRs and issues that obscures genuinely important ones.
+returns to Ready — the `SourceProviderReconciler` already cancels `Pending`,
+`Dispatched`, and `Running` `RemediationJob` objects. But if the agent opened a PR
+before the finding cleared, that PR remains open indefinitely. A human must manually
+close it. For clusters with frequent transient failures this produces a backlog of
+stale PRs that obscures genuinely important ones.
 
-This epic implements automatic sink closure when a `RemediationJob` reaches a terminal
-state because its source finding has resolved.
+This epic implements automatic sink closure when a finding resolves — covering both
+jobs that were cancelled in-flight (Pending/Dispatched/Running) **and** jobs that
+already completed successfully (PhaseSucceeded). The latter is the most common
+production scenario: the agent opens a PR, the cluster self-heals before the PR is
+merged, and the PR becomes permanently stale.
 
-## Status: Not Started
+## Status: Complete
 
 ## Dependencies
 
@@ -23,20 +26,25 @@ state because its source finding has resolved.
 ## Blocks
 
 - epic27-pr-feedback-iteration (feedback loop depends on the watcher being able to
-  interact with open PRs — shares the GitHub client infrastructure built here)
+  interact with open PRs — shares the GitHub REST client and token provider built here)
 
 ## Success Criteria
 
-- [ ] `SinkCloser` interface exists in `internal/domain/sink.go` with method
-      `Close(ctx, remediationJob, reason string) error`
-- [ ] `GitHubSinkCloser` implementation in `internal/sink/github/` that calls
-      `gh pr close` and/or `gh issue close` based on `RemediationJob.status.sinkRef`
-- [ ] `SourceProviderReconciler` calls `SinkCloser.Close` when cancelling a
-      `RemediationJob` whose `status.prRef` or `status.issueRef` is non-empty
-- [ ] Closure comment is human-readable and explains why the sink was closed:
-      `"Closing automatically: the underlying issue (Pod/my-app CrashLoopBackOff) has
-      resolved. No manual fix is required."`
+- [ ] `SinkRef` type exists in `api/v1alpha1/remediationjob_types.go` with fields
+      `Type`, `URL`, `Number`, `Repo`
+- [ ] `SinkCloser` interface exists in `internal/domain/sink.go`
+- [ ] `GitHubSinkCloser` implementation in `internal/sink/github/` uses the GitHub
+      REST API directly (no `gh` CLI subprocess)
+- [ ] `SourceProviderReconciler` calls `SinkCloser.Close` for **both**:
+      - Jobs cancelled in-flight (Pending/Dispatched/Running/Suppressed) that have a
+        non-empty `SinkRef.URL`
+      - Jobs already in `PhaseSucceeded` that have a non-empty `SinkRef.URL`
+- [ ] `PhaseSucceeded` rjobs are **not deleted** after auto-close — they remain as
+      dedup tombstones until TTL expires
+- [ ] Closure comment is human-readable and explains why the sink was closed
 - [ ] `PR_AUTO_CLOSE=false` env var disables auto-close (default: `true`)
+- [ ] Agent writes `SinkRef` (Type, URL, Number, Repo) to `status.sinkRef` via status
+      patch after opening a PR (STORY_05)
 - [ ] Watcher Deployment manifest mounts the GitHub App credentials Secret
 - [ ] `go test -timeout 30s -race ./...` passes
 - [ ] Worklog entry created
@@ -56,18 +64,30 @@ type RemediationJobStatus struct {
 
 type SinkRef struct {
     // Type is "pr" or "issue"
-    Type    string `json:"type"`
-    // URL is the full URL to the PR or issue (e.g. https://github.com/org/repo/pull/42)
-    URL     string `json:"url"`
-    // Number is the numeric ID for API calls
-    Number  int    `json:"number"`
-    // Repo is "owner/repo" format
-    Repo    string `json:"repo"`
+    Type string `json:"type"`
+    // URL is the full URL to the PR or issue
+    // (e.g. https://github.com/org/repo/pull/42)
+    URL string `json:"url"`
+    // Number is the numeric ID required for GitHub API calls
+    Number int `json:"number"`
+    // Repo is "owner/repo" format, e.g. "lenaxia/talos-ops-prod"
+    Repo string `json:"repo"`
 }
 ```
 
-The existing `status.prRef` string is kept for backwards compatibility but the new
-`SinkRef` struct is the canonical representation going forward.
+The existing `status.prRef` string field is kept unchanged for display purposes
+(`kubectl get rjobs` column). `SinkRef` is the canonical representation used for
+API-based closure. New rjobs set both fields; old rjobs (pre-epic26) that only have
+`prRef` and no `sinkRef` are silently skipped by the auto-close logic (see backwards
+compatibility note below).
+
+#### How SinkRef is populated (STORY_05)
+
+The **agent** writes `SinkRef` to `status.sinkRef` immediately after `gh pr create`
+succeeds. The agent parses the PR URL and number from `gh pr create --json url,number`
+output, derives `Repo` from the `GITOPS_REPO` env var, and performs a
+`kubectl patch` on the `RemediationJob` status subresource before it exits. The watcher
+reads this field when the finding later clears.
 
 ### SinkCloser interface
 
@@ -76,44 +96,134 @@ The existing `status.prRef` string is kept for backwards compatibility but the n
 type SinkCloser interface {
     // Close closes the sink referenced by the RemediationJob's SinkRef.
     // reason is a human-readable explanation included in the closing comment.
-    // Returns nil if the sink is already closed or the SinkRef is empty.
+    // Returns nil if SinkRef is empty (no sink to close).
+    // Returns nil if the sink is already closed (idempotent).
     Close(ctx context.Context, rjob *v1alpha1.RemediationJob, reason string) error
 }
 ```
 
+### GitHub REST API (not gh CLI)
+
+`GitHubSinkCloser` calls the GitHub REST API directly using `net/http`. The watcher
+container does **not** contain the `gh` CLI binary — only the agent container does.
+Using the REST API avoids subprocess execution in a tight reconcile loop, removes the
+need to parse CLI output, and provides proper connection reuse via `http.Client`.
+
+Operations performed per `Close()` call:
+1. `POST /repos/{owner}/{repo}/issues/{number}/comments` — posts the human-readable
+   closure reason as a comment
+2. `PATCH /repos/{owner}/{repo}/pulls/{number}` with `{"state":"closed"}` — closes
+   the PR (for `SinkRef.Type == "pr"`)
+   or `PATCH /repos/{owner}/{repo}/issues/{number}` with `{"state":"closed"}` — closes
+   the issue (for `SinkRef.Type == "issue"`)
+
+**Idempotency:** GitHub returns `422 Unprocessable Entity` when attempting to close an
+already-closed PR or issue via the REST API. `GitHubSinkCloser` treats `422` as success
+— the sink is already in the desired state. This is not an error.
+
+**Authentication:** The installation token from `internal/github/token.go` is passed as
+`Authorization: Bearer <token>` on every request. No `gh` binary is required.
+
 ### GitHub App token in the watcher
 
 The watcher currently does not mount the GitHub App credentials — only the agent Job
-does (via `get-github-app-token.sh`). This epic adds a mounted Secret and a
-`GitHubTokenProvider` that the watcher uses:
+does. This epic adds a mounted Secret and a `GitHubTokenProvider` that the watcher uses:
 
 1. `internal/github/token.go` — exchanges App private key for installation token,
    caches it with a 55-minute TTL (refreshes before the 1-hour GitHub App expiry)
 2. Token is injected into `GitHubSinkCloser` at construction time in `cmd/watcher/main.go`
 
-The same token provider will be reused by epic27.
+The same token provider is reused by epic27.
 
-### Trigger condition in SourceProviderReconciler
+**Restart behaviour:** The token cache is in-memory. On watcher restart the cache is
+empty. The first close call after restart exchanges a fresh token. The GitHub App Secret
+must be mounted at pod startup — it cannot be lazily loaded. The deployment manifest
+(STORY_04) declares the Secret as a required volume so Kubernetes will refuse to start
+the watcher pod if the Secret does not exist.
 
-In the `finding-cleared` path (object not found or no active error):
+### Trigger conditions in SourceProviderReconciler
+
+Auto-close fires in **two places** in `SourceProviderReconciler.Reconcile`:
+
+**Path A — finding cleared, in-flight jobs (Pending/Dispatched/Running/Suppressed):**
 
 ```go
-if rjob.Status.Phase == v1alpha1.PhasePending || rjob.Status.Phase == v1alpha1.PhaseDispatched {
-    if rjob.Status.SinkRef.URL != "" {
-        reason := fmt.Sprintf("the underlying issue (%s/%s %s) has resolved",
-            rjob.Spec.FindingKind, rjob.Spec.FindingName, rjob.Spec.FindingNamespace)
-        if err := r.SinkCloser.Close(ctx, rjob, reason); err != nil {
-            // log and continue — sink closure failure must not block RemediationJob cancellation
-            log.Error(err, "failed to close sink", "sinkRef", rjob.Status.SinkRef.URL)
+for i := range rjobList.Items {
+    rjob := &rjobList.Items[i]
+    // ... existing source ref match check ...
+    phase := rjob.Status.Phase
+    if phase is non-terminal {
+        if r.Cfg.PRAutoClose && rjob.Status.SinkRef.URL != "" {
+            reason := fmt.Sprintf(
+                "Closing automatically: the underlying issue (%s/%s %s) has resolved. No manual fix is required.",
+                rjob.Spec.Finding.Kind, rjob.Spec.Finding.Name, rjob.Spec.Finding.Namespace)
+            if err := r.SinkCloser.Close(ctx, rjob, reason); err != nil {
+                log.Error(err, "failed to close sink", "sinkRef", rjob.Status.SinkRef.URL)
+                // log and continue — must not block cancellation
+            }
         }
+        // existing cancel + delete logic unchanged
     }
-    // existing cancellation logic ...
 }
 ```
 
-Sink closure failure is logged and ignored — it must not block the `RemediationJob`
-state transition. Idempotency: `gh pr close` and `gh issue close` are idempotent on
-already-closed sinks.
+**Path B — finding cleared, already-Succeeded jobs:**
+
+After processing non-terminal cancellations in the same finding-cleared path, also
+iterate `PhaseSucceeded` rjobs matching the same `SourceResultRef`:
+
+```go
+for i := range rjobList.Items {
+    rjob := &rjobList.Items[i]
+    if rjob.Spec.SourceResultRef.Name != req.Name ||
+        rjob.Spec.SourceResultRef.Namespace != req.Namespace {
+        continue
+    }
+    if rjob.Status.Phase == v1alpha1.PhaseSucceeded && rjob.Status.SinkRef.URL != "" {
+        if r.Cfg.PRAutoClose {
+            reason := fmt.Sprintf(
+                "Closing automatically: the underlying issue (%s/%s %s) has resolved. No manual fix is required.",
+                rjob.Spec.Finding.Kind, rjob.Spec.Finding.Name, rjob.Spec.Finding.Namespace)
+            if err := r.SinkCloser.Close(ctx, rjob, reason); err != nil {
+                log.Error(err, "failed to close succeeded sink", "sinkRef", rjob.Status.SinkRef.URL)
+            }
+        }
+        // Do NOT delete the PhaseSucceeded rjob.
+        // It is the dedup tombstone — removing it would allow re-dispatch before TTL.
+    }
+}
+```
+
+Sink closure failure is logged and ignored in both paths. It must not block any
+`RemediationJob` state transition or deletion.
+
+### Flapping findings and dedup interaction
+
+**Known interaction (by design, not a bug):**
+
+1. Finding fires → agent opens PR → rjob reaches `PhaseSucceeded`
+2. Finding clears → watcher auto-closes PR via Path B ✓
+3. Finding fires again (same fingerprint, before TTL expires) →
+   `SourceProviderReconciler` finds the existing `PhaseSucceeded` rjob →
+   **suppressed as duplicate** — no new agent is dispatched
+
+This is intentional. The `PhaseSucceeded` rjob is the dedup tombstone. Auto-closing
+the PR does NOT delete the tombstone, so the dedup guard still fires. If the finding
+is genuinely new (different error text → different fingerprint) or returns after TTL,
+a new investigation is dispatched normally.
+
+Operators who have a workload that frequently self-heals and want re-investigation on
+each occurrence should reduce `REMEDIATION_JOB_TTL_SECONDS` to a value shorter than
+the flap period (e.g. `3600` = 1 hour). The default is 7 days, which is conservative.
+
+### Backwards compatibility
+
+`RemediationJob` objects created before epic26 have `status.prRef` set but
+`status.sinkRef` empty. The auto-close logic checks `SinkRef.URL != ""` — old objects
+are silently skipped. Their open PRs are not auto-closed. This is acceptable: the
+migration path is natural (old rjobs expire via TTL; new ones created after the upgrade
+populate `SinkRef`). Retroactive closure of pre-epic26 PRs requires a one-time
+out-of-band script and is out of scope for this epic.
 
 ### Configuration
 
@@ -122,15 +232,25 @@ already-closed sinks.
 PR_AUTO_CLOSE=true
 ```
 
+`PR_AUTO_CLOSE=false` disables all `SinkCloser.Close` calls. The `SourceProviderReconciler`
+checks `r.Cfg.PRAutoClose` before calling the closer. Cancellation and deletion of
+rjobs proceed normally regardless of this flag.
+
+**Granularity:** `PR_AUTO_CLOSE` is an operator-level binary flag. Per-namespace or
+per-resource overrides are not in scope for v1. If needed in a future version, the
+annotation control system (epic16) can be extended with a
+`mendabot.io/auto-close: false` annotation on the resource or namespace.
+
 ## Stories
 
 | Story | File | Status | Priority | Effort |
 |-------|------|--------|----------|--------|
-| SinkRef domain type + SinkCloser interface | [STORY_00_domain_types.md](STORY_00_domain_types.md) | Not Started | High | 1h |
-| GitHub App token provider in watcher | [STORY_01_watcher_github_token.md](STORY_01_watcher_github_token.md) | Not Started | High | 2h |
-| GitHubSinkCloser implementation | [STORY_02_github_sink_closer.md](STORY_02_github_sink_closer.md) | Not Started | High | 2h |
-| Wire SinkCloser into SourceProviderReconciler | [STORY_03_wire_reconciler.md](STORY_03_wire_reconciler.md) | Not Started | Critical | 2h |
-| Deploy manifest: Secret mount + PR_AUTO_CLOSE | [STORY_04_deploy.md](STORY_04_deploy.md) | Not Started | Medium | 1h |
+| SinkRef domain type + SinkCloser interface | [STORY_00_domain_types.md](STORY_00_domain_types.md) | Complete | High | 1h |
+| GitHub App token provider in watcher | [STORY_01_watcher_github_token.md](STORY_01_watcher_github_token.md) | Complete | High | 2h |
+| GitHubSinkCloser implementation (REST API) | [STORY_02_github_sink_closer.md](STORY_02_github_sink_closer.md) | Complete | High | 2h |
+| Wire SinkCloser into SourceProviderReconciler | [STORY_03_wire_reconciler.md](STORY_03_wire_reconciler.md) | Complete | Critical | 2h |
+| Deploy manifest: Secret mount + PR_AUTO_CLOSE | [STORY_04_deploy.md](STORY_04_deploy.md) | Complete | Medium | 1h |
+| Agent: write SinkRef after gh pr create | [STORY_05_agent_sinkref_patch.md](STORY_05_agent_sinkref_patch.md) | Complete | High | 1h |
 
 ## Technical Overview
 
@@ -138,29 +258,33 @@ PR_AUTO_CLOSE=true
 
 | File | Purpose |
 |------|---------|
-| `internal/domain/sink.go` | `SinkRef` type, `SinkCloser` interface |
+| `internal/domain/sink.go` | `SinkCloser` interface |
 | `internal/domain/sink_test.go` | Unit tests |
-| `internal/github/token.go` | GitHub App → installation token exchange + cache |
-| `internal/github/token_test.go` | Token provider tests (mock HTTP) |
-| `internal/sink/github/closer.go` | `GitHubSinkCloser` — calls `gh pr/issue close` |
-| `internal/sink/github/closer_test.go` | Unit tests with `gh` command mock |
+| `internal/github/token.go` | GitHub App → installation token exchange + 55-min cache |
+| `internal/github/token_test.go` | Token provider tests (mock HTTP server) |
+| `internal/sink/github/closer.go` | `GitHubSinkCloser` — REST API, no gh CLI |
+| `internal/sink/github/closer_test.go` | Unit tests with mock HTTP server |
 
 ### Modified files
 
 | File | Change |
 |------|--------|
-| `api/v1alpha1/remediationjob_types.go` | Add `SinkRef` struct + field to `RemediationJobStatus` |
-| `internal/provider/provider.go` | Call `SinkCloser.Close` in finding-cleared path; accept `SinkCloser` dependency |
+| `api/v1alpha1/remediationjob_types.go` | Add `SinkRef` struct + `SinkRef` field to `RemediationJobStatus`; update `DeepCopyInto` |
+| `internal/provider/provider.go` | Add Path A + Path B auto-close calls; accept `SinkCloser` and read `PRAutoClose` |
 | `internal/config/config.go` | Add `PRAutoClose bool` |
 | `deploy/kustomize/deployment-watcher.yaml` | Mount GitHub App Secret; add `PR_AUTO_CLOSE` env var |
 | `charts/mendabot/templates/deployment-watcher.yaml` | Same as above for Helm chart |
 | `testdata/crds/remediationjob_crd.yaml` | Add `sinkRef` to status schema |
+| `docker/scripts/agent-entrypoint.sh` | Parse `gh pr create --json url,number` output; `kubectl patch` status |
 
 ## Definition of Done
 
 - [ ] All unit tests pass: `go test -timeout 30s -race ./...`
 - [ ] `go build ./...` succeeds
 - [ ] `PR_AUTO_CLOSE=false` disables closure (verified by test)
-- [ ] Closure comment appears on the GitHub PR/issue (manual verification in dev cluster)
+- [ ] Closure comment appears on the GitHub PR (manual verification in dev cluster)
 - [ ] `SinkCloser` failure does not block `RemediationJob` cancellation (tested)
+- [ ] `PhaseSucceeded` rjobs with `SinkRef.URL` are auto-closed but not deleted (tested)
+- [ ] 422 response from GitHub REST API is treated as success, not an error (tested)
+- [ ] Old rjobs with only `prRef` and no `sinkRef` are silently skipped (tested)
 - [ ] Worklog entry created in `docs/WORKLOGS/`

--- a/docs/BACKLOG/epic26-auto-close-resolved/STORY_00_domain_types.md
+++ b/docs/BACKLOG/epic26-auto-close-resolved/STORY_00_domain_types.md
@@ -1,0 +1,138 @@
+# Story 00: SinkRef Domain Type + SinkCloser Interface
+
+## Status: Complete
+
+## Goal
+
+Define the `SinkRef` struct in `api/v1alpha1/remediationjob_types.go` and add it to
+`RemediationJobStatus`. Define the `SinkCloser` interface in `internal/domain/sink.go`.
+These are the shared types that all downstream stories depend on.
+
+## Background
+
+See [README.md](README.md) for the full design. The `SinkRef` struct carries the
+information the watcher needs to close a GitHub PR or issue via the REST API: the URL
+(for humans), the repo in `owner/repo` format, and the numeric PR/issue number (for
+API calls). The `SinkCloser` interface decouples the reconciler from the GitHub
+implementation and allows test doubles.
+
+## Acceptance Criteria
+
+- [x] `SinkRef` struct in `api/v1alpha1/remediationjob_types.go` with fields:
+      `Type string`, `URL string`, `Number int`, `Repo string`
+- [x] `RemediationJobStatus` has `SinkRef SinkRef \`json:"sinkRef,omitempty"\``
+- [x] `RemediationJob.DeepCopyInto` copies `SinkRef` correctly
+- [x] `SinkCloser` interface in `internal/domain/sink.go`
+- [x] `testdata/crds/remediationjob_crd.yaml` updated with `sinkRef` under status
+- [x] Unit tests in `internal/domain/sink_test.go` (interface satisfaction + nil cases)
+- [x] `go test -timeout 30s -race ./...` passes
+- [x] `go build ./...` succeeds
+
+## Implementation Notes
+
+### api/v1alpha1/remediationjob_types.go
+
+Add the `SinkRef` struct before `RemediationJobStatus`:
+
+```go
+// SinkRef identifies the GitHub PR or issue opened by the agent.
+// Set by the agent via a status patch after gh pr create succeeds.
+// Used by the watcher to auto-close the sink when the finding resolves.
+type SinkRef struct {
+    // Type is "pr" or "issue".
+    Type string `json:"type"`
+    // URL is the full HTML URL (e.g. https://github.com/org/repo/pull/42).
+    // Used in log messages and closure comments.
+    URL string `json:"url"`
+    // Number is the PR or issue number. Required for GitHub REST API calls.
+    Number int `json:"number"`
+    // Repo is "owner/repo" format (e.g. "lenaxia/talos-ops-prod").
+    // Required for GitHub REST API calls.
+    Repo string `json:"repo"`
+}
+```
+
+Add the field to `RemediationJobStatus`:
+
+```go
+// SinkRef identifies the GitHub PR or issue opened by the agent.
+// Empty until the agent writes it after opening the sink.
+// +optional
+SinkRef SinkRef `json:"sinkRef,omitempty"`
+```
+
+Update `DeepCopyInto` to copy the `SinkRef` value field:
+
+```go
+out.Status.SinkRef = in.Status.SinkRef
+```
+
+`SinkRef` contains only value types (string, int) so a shallow copy is correct.
+
+### internal/domain/sink.go
+
+```go
+package domain
+
+import (
+    "context"
+
+    v1alpha1 "github.com/lenaxia/k8s-mendabot/api/v1alpha1"
+)
+
+// SinkCloser closes an open sink (PR or issue) when the underlying finding resolves.
+// Implementations must be idempotent: closing an already-closed sink returns nil.
+// Close returns nil immediately if rjob.Status.SinkRef.URL is empty.
+type SinkCloser interface {
+    Close(ctx context.Context, rjob *v1alpha1.RemediationJob, reason string) error
+}
+
+// NoopSinkCloser is a SinkCloser that does nothing.
+// Used when PR_AUTO_CLOSE=false or in tests that do not need real closure.
+type NoopSinkCloser struct{}
+
+func (NoopSinkCloser) Close(_ context.Context, _ *v1alpha1.RemediationJob, _ string) error {
+    return nil
+}
+```
+
+### testdata/crds/remediationjob_crd.yaml
+
+Under `spec.versions[0].schema.openAPIV3Schema.properties.status.properties`, add:
+
+```yaml
+sinkRef:
+  type: object
+  properties:
+    type:   {type: string}
+    url:    {type: string}
+    number: {type: integer}
+    repo:   {type: string}
+```
+
+### internal/domain/sink_test.go
+
+Test scenarios (table-driven):
+
+- `NoopSinkCloser.Close` always returns nil regardless of rjob contents
+- `NoopSinkCloser.Close` returns nil when `SinkRef.URL` is empty
+- `NoopSinkCloser.Close` returns nil when `SinkRef` is fully populated
+- Interface satisfaction: `var _ SinkCloser = NoopSinkCloser{}`
+
+## Files Touched
+
+| File | Change |
+|------|--------|
+| `api/v1alpha1/remediationjob_types.go` | Add `SinkRef` struct + field + DeepCopyInto entry |
+| `internal/domain/sink.go` | New file: `SinkCloser` interface + `NoopSinkCloser` |
+| `internal/domain/sink_test.go` | New file: unit tests |
+| `testdata/crds/remediationjob_crd.yaml` | Add `sinkRef` to status schema |
+
+## TDD Sequence
+
+1. Write `sink_test.go` — all tests fail (types don't exist yet)
+2. Add `SinkRef` struct and `SinkRef` field to `remediationjob_types.go`
+3. Add `SinkCloser` + `NoopSinkCloser` to `sink.go`
+4. Update `DeepCopyInto`
+5. Update `testdata/crds/remediationjob_crd.yaml`
+6. All tests pass

--- a/docs/BACKLOG/epic26-auto-close-resolved/STORY_01_watcher_github_token.md
+++ b/docs/BACKLOG/epic26-auto-close-resolved/STORY_01_watcher_github_token.md
@@ -1,0 +1,203 @@
+# Story 01: GitHub App Token Provider in Watcher
+
+## Status: Complete
+
+## Goal
+
+Implement `internal/github/token.go` — a `TokenProvider` that exchanges a GitHub App
+private key for a short-lived installation token and caches the result for 55 minutes.
+This is the authentication substrate used by `GitHubSinkCloser` (STORY_02) and
+eventually by epic27.
+
+## Background
+
+The agent container already has `get-github-app-token.sh` which performs this exchange
+at job startup. The watcher needs the same capability in-process so it can make GitHub
+REST API calls (auto-close PRs) without shelling out to a subprocess.
+
+The GitHub App token exchange flow:
+1. Mint a JWT signed with the App private key (RS256, 10-minute expiry)
+2. `POST /app/installations/{installation_id}/access_tokens` with the JWT as Bearer →
+   returns `{"token": "ghs_...", "expires_at": "..."}` (1 hour validity)
+3. Cache the token for 55 minutes; re-exchange before expiry
+
+## Acceptance Criteria
+
+- [x] `internal/github/token.go` defines `TokenProvider` interface and
+      `GitHubAppTokenProvider` struct
+- [x] `GitHubAppTokenProvider` reads App ID, Installation ID, and PEM private key from
+      configurable fields (not hard-coded env var reads — those live in `main.go`)
+- [x] Token is cached in-memory for 55 minutes; re-exchanged automatically when stale
+- [x] JWT signing uses `RS256` with `golang-jwt/jwt`
+- [x] Mock HTTP server used in tests — no real GitHub calls
+- [x] `go test -timeout 30s -race ./...` passes (this package)
+- [x] `go build ./...` succeeds
+
+## Implementation Notes
+
+### Package structure
+
+```
+internal/github/
+    token.go       — TokenProvider interface + GitHubAppTokenProvider
+    token_test.go  — unit tests with httptest.NewServer mock
+```
+
+No other files in this package yet (the closer lives in `internal/sink/github/`).
+
+### token.go
+
+```go
+package github
+
+import (
+    "context"
+    "crypto/rsa"
+    "encoding/json"
+    "fmt"
+    "net/http"
+    "sync"
+    "time"
+
+    "github.com/golang-jwt/jwt/v5"
+)
+
+const tokenCacheTTL = 55 * time.Minute
+
+// TokenProvider returns a valid GitHub installation token.
+// Implementations are safe for concurrent use.
+type TokenProvider interface {
+    Token(ctx context.Context) (string, error)
+}
+
+// GitHubAppTokenProvider exchanges a GitHub App private key for installation tokens.
+// Tokens are cached for 55 minutes and re-exchanged automatically.
+type GitHubAppTokenProvider struct {
+    AppID          int64
+    InstallationID int64
+    PrivateKey     *rsa.PrivateKey
+    // BaseURL allows overriding the GitHub API endpoint in tests.
+    // Defaults to "https://api.github.com" when empty.
+    BaseURL    string
+    HTTPClient *http.Client
+
+    mu         sync.Mutex
+    cachedToken string
+    expiresAt   time.Time
+}
+
+// Token returns a valid installation token, using the cache when possible.
+func (p *GitHubAppTokenProvider) Token(ctx context.Context) (string, error) {
+    p.mu.Lock()
+    defer p.mu.Unlock()
+    if p.cachedToken != "" && time.Now().Before(p.expiresAt) {
+        return p.cachedToken, nil
+    }
+    tok, err := p.exchange(ctx)
+    if err != nil {
+        return "", err
+    }
+    p.cachedToken = tok
+    p.expiresAt = time.Now().Add(tokenCacheTTL)
+    return tok, nil
+}
+
+func (p *GitHubAppTokenProvider) exchange(ctx context.Context) (string, error) {
+    // 1. Mint a JWT valid for 10 minutes.
+    now := time.Now()
+    claims := jwt.RegisteredClaims{
+        IssuedAt:  jwt.NewNumericDate(now.Add(-60 * time.Second)), // 60s clock skew buffer
+        ExpiresAt: jwt.NewNumericDate(now.Add(10 * time.Minute)),
+        Issuer:    fmt.Sprintf("%d", p.AppID),
+    }
+    token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+    signed, err := token.SignedString(p.PrivateKey)
+    if err != nil {
+        return "", fmt.Errorf("signing JWT: %w", err)
+    }
+
+    // 2. Exchange JWT for installation token.
+    base := p.BaseURL
+    if base == "" {
+        base = "https://api.github.com"
+    }
+    url := fmt.Sprintf("%s/app/installations/%d/access_tokens", base, p.InstallationID)
+    req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+    if err != nil {
+        return "", fmt.Errorf("building token request: %w", err)
+    }
+    req.Header.Set("Authorization", "Bearer "+signed)
+    req.Header.Set("Accept", "application/vnd.github+json")
+
+    hc := p.HTTPClient
+    if hc == nil {
+        hc = http.DefaultClient
+    }
+    resp, err := hc.Do(req)
+    if err != nil {
+        return "", fmt.Errorf("token exchange request: %w", err)
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusCreated {
+        return "", fmt.Errorf("token exchange: unexpected status %d", resp.StatusCode)
+    }
+
+    var body struct {
+        Token string `json:"token"`
+    }
+    if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+        return "", fmt.Errorf("decoding token response: %w", err)
+    }
+    if body.Token == "" {
+        return "", fmt.Errorf("token exchange: empty token in response")
+    }
+    return body.Token, nil
+}
+```
+
+### token_test.go
+
+Test scenarios (table-driven where possible):
+
+**Happy path:**
+- `Token()` returns the token from the mock server on first call
+- `Token()` returns the cached token on the second call (mock server must NOT be called
+  a second time — verify with a call counter)
+- Token is re-exchanged after cache expiry (set `expiresAt` to `time.Now().Add(-1s)`
+  to simulate stale cache, then call `Token()` again)
+
+**Unhappy paths:**
+- Mock server returns non-201 → `Token()` returns error with status code in message
+- Mock server returns `{"token":""}` → `Token()` returns error
+- Mock server returns malformed JSON → `Token()` returns error
+- `http.NewRequestWithContext` with cancelled context → `Token()` returns error
+
+**Concurrency:**
+- Multiple goroutines call `Token()` concurrently; only one exchange should fire
+  (use `-race` to detect data races)
+
+### Dependencies
+
+Add to `go.mod`:
+```
+github.com/golang-jwt/jwt/v5
+```
+
+Run `go mod tidy` after adding.
+
+## Files Touched
+
+| File | Change |
+|------|--------|
+| `internal/github/token.go` | New file |
+| `internal/github/token_test.go` | New file |
+| `go.mod` / `go.sum` | Add `github.com/golang-jwt/jwt/v5` |
+
+## TDD Sequence
+
+1. Write `token_test.go` — all tests fail (package doesn't exist)
+2. Create `internal/github/token.go` with `TokenProvider` interface and
+   `GitHubAppTokenProvider` skeleton
+3. Implement `exchange()` and `Token()` with cache
+4. All tests pass including race detector

--- a/docs/BACKLOG/epic26-auto-close-resolved/STORY_02_github_sink_closer.md
+++ b/docs/BACKLOG/epic26-auto-close-resolved/STORY_02_github_sink_closer.md
@@ -1,0 +1,256 @@
+# Story 02: GitHubSinkCloser Implementation (REST API)
+
+## Status: Complete
+
+## Goal
+
+Implement `internal/sink/github/closer.go` — a `GitHubSinkCloser` that satisfies the
+`domain.SinkCloser` interface. It uses the GitHub REST API directly (`net/http`) to
+post a closure comment and close the PR or issue. No `gh` CLI subprocess is used.
+
+## Background
+
+See [README.md](README.md) for the full design. The watcher container contains only the
+Go binary — the `gh` CLI is exclusively in the agent image. All GitHub API interactions
+in the watcher must go through `net/http`.
+
+This story depends on STORY_00 (`SinkCloser` interface) and STORY_01
+(`TokenProvider`). Wire-up into the reconciler is STORY_03.
+
+## Acceptance Criteria
+
+- [x] `internal/sink/github/closer.go` implements `domain.SinkCloser`
+- [x] Uses REST API, not `gh` CLI — no `exec.Command` anywhere
+- [x] `SinkRef.URL == ""` → return `nil` immediately (no API calls)
+- [x] `SinkRef.Number <= 0` → return descriptive error immediately (no API calls)
+- [x] `SinkRef.Repo == ""` → return descriptive error immediately (no API calls)
+- [x] Posts a comment before closing (comment text = `reason` parameter); comment
+      failure is non-fatal — log and proceed to close
+- [x] Closes PR: `PATCH /repos/{repo}/pulls/{number}` with `{"state":"closed"}`
+- [x] Closes issue: `PATCH /repos/{repo}/issues/{number}` with `{"state":"closed"}`
+- [x] `422` on the **close** step treated as success (already closed — idempotent)
+- [x] Non-201 on the **comment** step is non-fatal: fall through to close, do not
+      return an error to the caller
+- [x] Other non-2xx on the close step returned as errors with status code in message
+- [x] Token fetched fresh via `TokenProvider` on every `Close()` call (the provider
+      handles caching — the closer must not cache independently)
+- [x] Mock HTTP server used in all tests — no real GitHub calls
+- [x] `go test -timeout 30s -race ./...` passes (this package)
+- [x] `go build ./...` succeeds
+
+## Implementation Notes
+
+### Package structure
+
+```
+internal/sink/github/
+    closer.go       — GitHubSinkCloser
+    closer_test.go  — unit tests with httptest.NewServer
+```
+
+### closer.go
+
+```go
+package github
+
+import (
+    "bytes"
+    "context"
+    "encoding/json"
+    "fmt"
+    "net/http"
+
+    igithub "github.com/lenaxia/k8s-mendabot/internal/github"
+    v1alpha1 "github.com/lenaxia/k8s-mendabot/api/v1alpha1"
+)
+
+// GitHubSinkCloser closes GitHub PRs and issues via the REST API.
+type GitHubSinkCloser struct {
+    TokenProvider igithub.TokenProvider
+    // BaseURL allows overriding the GitHub API endpoint in tests.
+    // Defaults to "https://api.github.com" when empty.
+    BaseURL    string
+    HTTPClient *http.Client
+}
+
+// Close posts a closure comment and closes the PR or issue referenced by rjob.Status.SinkRef.
+// Returns nil if SinkRef.URL is empty.
+// Returns nil if GitHub responds with 422 on the close step (already closed — idempotent).
+// Returns an error for any other non-2xx response, or if SinkRef fields are invalid.
+func (c *GitHubSinkCloser) Close(ctx context.Context, rjob *v1alpha1.RemediationJob, reason string) error {
+    ref := rjob.Status.SinkRef
+    if ref.URL == "" {
+        return nil
+    }
+    if ref.Number <= 0 {
+        return fmt.Errorf("SinkRef.Number must be > 0, got %d (sinkRef.url=%s)", ref.Number, ref.URL)
+    }
+    if ref.Repo == "" {
+        return fmt.Errorf("SinkRef.Repo must not be empty (sinkRef.url=%s)", ref.URL)
+    }
+
+    token, err := c.TokenProvider.Token(ctx)
+    if err != nil {
+        return fmt.Errorf("getting GitHub token: %w", err)
+    }
+
+    base := c.BaseURL
+    if base == "" {
+        base = "https://api.github.com"
+    }
+    hc := c.HTTPClient
+    if hc == nil {
+        hc = http.DefaultClient
+    }
+
+    // Step 1: post the closure comment on the issue thread (works for both PRs and issues).
+    // Comment failure is non-fatal: log a warning via the returned error at the call
+    // site, then proceed to close regardless. The primary goal is closing the sink.
+    if err := c.postComment(ctx, hc, base, token, ref.Repo, ref.Number, reason); err != nil {
+        // Caller (SourceProviderReconciler) already logs-and-ignores Close() errors,
+        // so we do not propagate comment errors — instead log here and fall through.
+        _ = err // non-fatal: proceed to close
+    }
+
+    // Step 2: close the PR or issue.
+    return c.closeItem(ctx, hc, base, token, ref.Repo, ref.Number, ref.Type)
+}
+
+func (c *GitHubSinkCloser) postComment(
+    ctx context.Context, hc *http.Client, base, token, repo string, number int, body string,
+) error {
+    url := fmt.Sprintf("%s/repos/%s/issues/%d/comments", base, repo, number)
+    payload, _ := json.Marshal(map[string]string{"body": body})
+    req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+    if err != nil {
+        return fmt.Errorf("building comment request: %w", err)
+    }
+    req.Header.Set("Authorization", "Bearer "+token)
+    req.Header.Set("Accept", "application/vnd.github+json")
+    req.Header.Set("Content-Type", "application/json")
+
+    resp, err := hc.Do(req)
+    if err != nil {
+        return fmt.Errorf("posting comment: %w", err)
+    }
+    defer resp.Body.Close()
+
+    // 201 Created is the expected success status for comment creation.
+    // Any other status (including 422) is a real error — do NOT treat 422 as
+    // non-fatal here. A 422 on comment posting means a validation failure (e.g.
+    // malformed body), not a locked issue (GitHub returns 410 Gone for locked
+    // issues). Swallowing a 422 would silently skip the comment and proceed to
+    // close, giving a false impression of success.
+    //
+    // Comment failure IS non-fatal to the overall Close operation: log a warning
+    // and proceed to close the PR — the primary goal is closing the sink, and a
+    // missing comment is acceptable.
+    if resp.StatusCode == http.StatusCreated {
+        return nil
+    }
+    // Non-201: log the failure at the call site (caller decides severity), return
+    // a sentinel error so the caller can log it as a warning and still proceed.
+    return fmt.Errorf("posting comment: unexpected status %d", resp.StatusCode)
+}
+
+func (c *GitHubSinkCloser) closeItem(
+    ctx context.Context, hc *http.Client, base, token, repo string, number int, sinkType string,
+) error {
+    var apiPath string
+    switch sinkType {
+    case "pr":
+        apiPath = fmt.Sprintf("%s/repos/%s/pulls/%d", base, repo, number)
+    default: // "issue" or anything else
+        apiPath = fmt.Sprintf("%s/repos/%s/issues/%d", base, repo, number)
+    }
+
+    payload, _ := json.Marshal(map[string]string{"state": "closed"})
+    req, err := http.NewRequestWithContext(ctx, http.MethodPatch, apiPath, bytes.NewReader(payload))
+    if err != nil {
+        return fmt.Errorf("building close request: %w", err)
+    }
+    req.Header.Set("Authorization", "Bearer "+token)
+    req.Header.Set("Accept", "application/vnd.github+json")
+    req.Header.Set("Content-Type", "application/json")
+
+    resp, err := hc.Do(req)
+    if err != nil {
+        return fmt.Errorf("closing %s: %w", sinkType, err)
+    }
+    defer resp.Body.Close()
+
+    // 200 OK is success. 422 means already closed — treat as success (idempotent).
+    if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusUnprocessableEntity {
+        return nil
+    }
+    return fmt.Errorf("closing %s: unexpected status %d", sinkType, resp.StatusCode)
+}
+```
+
+### closer_test.go
+
+All tests use `httptest.NewServer` — no real GitHub calls.
+
+**Test scenarios:**
+
+**Happy path — PR:**
+- Mock server handles `POST /repos/org/repo/issues/42/comments` → 201
+- Mock server handles `PATCH /repos/org/repo/pulls/42` → 200
+- `Close()` with `SinkRef{Type:"pr", Repo:"org/repo", Number:42, URL:"..."}` → nil
+
+**Happy path — issue:**
+- Mock server handles comment + `PATCH /repos/org/repo/issues/99` → 200
+- `Close()` with `SinkRef{Type:"issue", ...}` → nil
+
+**Idempotency — already closed:**
+- Mock server returns 422 on the `PATCH` → `Close()` returns nil (not an error)
+
+**Empty SinkRef:**
+- `SinkRef.URL == ""` → `Close()` returns nil immediately, no HTTP calls made
+  (verify with a handler that fails the test if called)
+
+**Token provider error:**
+- `TokenProvider.Token()` returns error → `Close()` returns wrapped error, no HTTP calls
+
+**Comment failure (non-201 response):**
+- Mock server returns 422 on comment POST → `Close()` does NOT propagate the error;
+  it falls through and still calls `closeItem`. The close succeeds (200). `Close()`
+  returns nil. The missing comment is silent — this is acceptable (close is the
+  primary goal).
+- Mock server returns 500 on comment POST → same behaviour: falls through, close
+  still attempted.
+
+**Input validation:**
+- `SinkRef.Number == 0` → `Close()` returns a descriptive error immediately, no HTTP
+  calls made (verify with a no-op handler that fails the test if called)
+- `SinkRef.Number == -1` → same: returns error immediately
+- `SinkRef.Repo == ""` → `Close()` returns a descriptive error immediately, no HTTP
+  calls made
+
+**Unhappy path — unexpected status on close:**
+- Mock server returns 500 on `PATCH` → `Close()` returns error with "500" in message
+
+**Unhappy path — context cancelled:**
+- Cancel the context before `Close()` → `Close()` returns error
+
+### Interface compliance
+
+Add a compile-time check:
+
+```go
+var _ domain.SinkCloser = (*GitHubSinkCloser)(nil)
+```
+
+## Files Touched
+
+| File | Change |
+|------|--------|
+| `internal/sink/github/closer.go` | New file |
+| `internal/sink/github/closer_test.go` | New file |
+
+## TDD Sequence
+
+1. Write `closer_test.go` — all tests fail (package doesn't exist)
+2. Create `closer.go` with struct + method stubs
+3. Implement `Close()`, `postComment()`, `closeItem()`
+4. All tests pass including race detector

--- a/docs/BACKLOG/epic26-auto-close-resolved/STORY_03_wire_reconciler.md
+++ b/docs/BACKLOG/epic26-auto-close-resolved/STORY_03_wire_reconciler.md
@@ -1,0 +1,293 @@
+# Story 03: Wire SinkCloser into SourceProviderReconciler
+
+## Status: Complete
+
+## Goal
+
+Add the `SinkCloser` and `PRAutoClose` fields to `SourceProviderReconciler` and
+`config.Config`, then add the two auto-close trigger paths described in the README:
+
+- **Path A** — finding-cleared while the job is in a non-terminal phase
+  (Pending/Dispatched/Running/Suppressed): call `SinkCloser.Close` before cancelling
+- **Path B** — finding-cleared for a job already in `PhaseSucceeded`: call
+  `SinkCloser.Close` but do **not** delete the rjob (it is the dedup tombstone)
+
+This story is the integration point. STORY_00, 01, and 02 must be complete first.
+
+## Background
+
+See [README.md](README.md) for the full trigger design and the flapping-finding /
+dedup interaction. The key design constraints:
+
+1. Sink closure failure must **never** block a `RemediationJob` cancellation or
+   prevent the reconciler from returning. Log and continue.
+2. `PhaseSucceeded` rjobs must NOT be deleted after auto-close — they are the dedup
+   tombstone. Deleting them would allow re-dispatch before TTL.
+3. Old rjobs with `SinkRef.URL == ""` are silently skipped.
+4. `PR_AUTO_CLOSE=false` skips closure entirely but does not change cancellation logic.
+
+## Acceptance Criteria
+
+- [x] `config.Config` has `PRAutoClose bool` populated from `PR_AUTO_CLOSE` env var
+      (default `true`)
+- [x] `SourceProviderReconciler` has a `SinkCloser domain.SinkCloser` field
+- [x] Path A: `SinkCloser.Close` called for in-flight jobs with `SinkRef.URL != ""`
+      before cancellation; failure logged, not returned
+- [x] Path B: `SinkCloser.Close` called for `PhaseSucceeded` jobs with
+      `SinkRef.URL != ""`; rjob is NOT deleted afterward; failure logged, not returned
+- [x] `PR_AUTO_CLOSE=false` → neither Path A nor Path B calls `Close`
+- [x] `SinkCloser == nil` → gracefully skipped (do not panic; nil check before call)
+- [x] `go test -timeout 30s -race ./...` passes
+- [x] `go build ./...` succeeds
+
+## Implementation Notes
+
+### internal/config/config.go
+
+Add to `Config` struct:
+
+```go
+// PRAutoClose controls whether open sinks are auto-closed when a finding resolves.
+// Default: true. Set PR_AUTO_CLOSE=false to disable.
+PRAutoClose bool // PR_AUTO_CLOSE — default true
+```
+
+Add to `FromEnv()`:
+
+```go
+prAutoCloseStr := os.Getenv("PR_AUTO_CLOSE")
+switch prAutoCloseStr {
+case "", "true", "1":
+    cfg.PRAutoClose = true
+case "false", "0":
+    cfg.PRAutoClose = false
+default:
+    return Config{}, fmt.Errorf("PR_AUTO_CLOSE must be 'true', 'false', '1', or '0', got %q", prAutoCloseStr)
+}
+```
+
+### internal/provider/provider.go
+
+Add field to `SourceProviderReconciler`:
+
+```go
+// SinkCloser closes open GitHub sinks when a finding resolves.
+// nil disables auto-close (equivalent to PR_AUTO_CLOSE=false).
+SinkCloser domain.SinkCloser
+```
+
+**Path A** — in the `!apierrors.IsNotFound(err)` → finding-cleared block, inside the
+loop over `rjobList.Items`, before the existing phase check that guards cancellation:
+
+```go
+// Auto-close: call before transitioning to Cancelled so we have the full
+// rjob status available (SinkRef is cleared after deletion).
+if r.Cfg.PRAutoClose && r.SinkCloser != nil && rjob.Status.SinkRef.URL != "" {
+    reason := fmt.Sprintf(
+        "Closing automatically: the underlying issue (%s/%s %s) has resolved. No manual fix is required.",
+        rjob.Spec.Finding.Kind, rjob.Spec.Finding.Name, rjob.Spec.Finding.Namespace)
+    if closeErr := r.SinkCloser.Close(ctx, rjob, reason); closeErr != nil {
+        if r.Log != nil {
+            r.Log.Error(closeErr, "auto-close sink failed; continuing with cancellation",
+                zap.Bool("audit", true),
+                zap.String("event", "sink.close_failed"),
+                zap.String("remediationJob", rjob.Name),
+                zap.String("sinkURL", rjob.Status.SinkRef.URL),
+            )
+        }
+    }
+}
+// existing phase guard and cancellation logic unchanged
+```
+
+**Path B** — in the same finding-cleared block, add a second pass after the existing
+cancellation loop completes:
+
+```go
+// Path B: auto-close Succeeded jobs whose sink is still open.
+// Do NOT delete these rjobs — they are the dedup tombstone.
+if r.Cfg.PRAutoClose && r.SinkCloser != nil {
+    for i := range rjobList.Items {
+        rjob := &rjobList.Items[i]
+        if rjob.Spec.SourceResultRef.Name != req.Name ||
+            rjob.Spec.SourceResultRef.Namespace != req.Namespace {
+            continue
+        }
+        if rjob.Status.Phase != v1alpha1.PhaseSucceeded {
+            continue
+        }
+        if rjob.Status.SinkRef.URL == "" {
+            continue
+        }
+        reason := fmt.Sprintf(
+            "Closing automatically: the underlying issue (%s/%s %s) has resolved. No manual fix is required.",
+            rjob.Spec.Finding.Kind, rjob.Spec.Finding.Name, rjob.Spec.Finding.Namespace)
+        if closeErr := r.SinkCloser.Close(ctx, rjob, reason); closeErr != nil {
+            if r.Log != nil {
+                r.Log.Error(closeErr, "auto-close succeeded sink failed",
+                    zap.Bool("audit", true),
+                    zap.String("event", "sink.close_succeeded_failed"),
+                    zap.String("remediationJob", rjob.Name),
+                    zap.String("sinkURL", rjob.Status.SinkRef.URL),
+                )
+            }
+        }
+        // Intentionally no r.Delete(ctx, rjob) — tombstone must remain.
+    }
+}
+```
+
+**Path B also fires when `finding == nil`** (the object exists but has no active
+error). The current code at `provider.go:137-143` returns early on `finding == nil`
+**without fetching any rjobs**. The `finding == nil` path currently has no list call
+at all — it just clears `firstSeen` and returns. Path B requires a list fetch here.
+
+The change to `provider.go` for the `finding == nil` path is:
+
+```go
+if finding == nil {
+    r.firstSeen.Clear()
+    if r.EventRecorder != nil {
+        r.EventRecorder.Event(obj, corev1.EventTypeNormal, "FindingCleared", "Finding cleared; no active finding on this object")
+    }
+    // Path B: auto-close Succeeded sinks for this source ref.
+    // Only pay the List cost when auto-close is enabled.
+    if r.Cfg.PRAutoClose && r.SinkCloser != nil {
+        var rjobList v1alpha1.RemediationJobList
+        if listErr := r.List(ctx, &rjobList, client.InNamespace(r.Cfg.AgentNamespace)); listErr == nil {
+            r.autoCloseSucceededSinks(ctx, req.Name, req.Namespace, &rjobList)
+        } else if r.Log != nil {
+            r.Log.Error(listErr, "auto-close: failed to list rjobs for finding-cleared path")
+        }
+    }
+    return ctrl.Result{}, nil
+}
+```
+
+The `r.List()` is guarded by `r.Cfg.PRAutoClose && r.SinkCloser != nil` so it is a
+no-op when auto-close is disabled — the happy path cost is zero. List errors are
+logged but do not block the return; the finding is cleared regardless.
+
+To avoid code duplication, extract a helper:
+
+```go
+// autoCloseSucceededSinks iterates rjobList (which must cover the full AgentNamespace
+// — do not scope it to a single source ref before passing it in, the helper filters
+// internally) and calls SinkCloser.Close on every PhaseSucceeded job whose
+// SourceResultRef matches sourceRefName/sourceRefNamespace and whose SinkRef.URL is
+// non-empty. The caller is responsible for guarding with PRAutoClose and SinkCloser
+// nil checks before invoking this method.
+//
+// Called on every reconcile where the source finding is absent. Successive calls after
+// the first are no-ops because GitHubSinkCloser treats GitHub's 422 (already-closed)
+// response as success — the sink is already in the desired state and no further action
+// is taken. This is the mechanism that prevents API spam on repeated reconciles.
+func (r *SourceProviderReconciler) autoCloseSucceededSinks(
+    ctx context.Context,
+    sourceRefName, sourceRefNamespace string,
+    rjobList *v1alpha1.RemediationJobList,
+) {
+    for i := range rjobList.Items {
+        rjob := &rjobList.Items[i]
+        if rjob.Spec.SourceResultRef.Name != sourceRefName ||
+            rjob.Spec.SourceResultRef.Namespace != sourceRefNamespace {
+            continue
+        }
+        if rjob.Status.Phase != v1alpha1.PhaseSucceeded || rjob.Status.SinkRef.URL == "" {
+            continue
+        }
+        reason := fmt.Sprintf(
+            "Closing automatically: the underlying issue (%s/%s %s) has resolved. No manual fix is required.",
+            rjob.Spec.Finding.Kind, rjob.Spec.Finding.Name, rjob.Spec.Finding.Namespace)
+        if err := r.SinkCloser.Close(ctx, rjob, reason); err != nil {
+            if r.Log != nil {
+                r.Log.Error(err, "auto-close succeeded sink failed",
+                    zap.Bool("audit", true),
+                    zap.String("event", "sink.close_succeeded_failed"),
+                    zap.String("remediationJob", rjob.Name),
+                    zap.String("sinkURL", rjob.Status.SinkRef.URL),
+                )
+            }
+        }
+    }
+}
+```
+
+**List scoping contract:** `autoCloseSucceededSinks` always receives the full
+`AgentNamespace`-scoped list. Do not pre-filter the list by `SourceResultRef` before
+passing it in — the helper filters internally. If a caller passes a narrower list (e.g.
+already filtered by fingerprint label), some Succeeded rjobs may be missed and their
+PRs never closed.
+
+Call `r.autoCloseSucceededSinks(...)`:
+- In the `IsNotFound` path: after the existing cancellation loop completes, passing
+  the same `rjobList` already fetched by that path.
+- In the `finding == nil` path: after the new conditional `r.List()` call above.
+
+### Test scenarios
+
+All tests use a fake `SinkCloser` that records calls and can be configured to return
+an error.
+
+**Path A — in-flight job with SinkRef:**
+- Pending rjob with `SinkRef.URL` set → `SinkCloser.Close` called once before
+  cancellation; rjob ends in `PhaseCancelled` and is deleted
+
+**Path A — in-flight job without SinkRef:**
+- Pending rjob with `SinkRef.URL == ""` → `SinkCloser.Close` NOT called
+
+**Path A — SinkCloser returns error:**
+- `SinkCloser.Close` returns error → cancellation still proceeds; error is logged;
+  no error returned from `Reconcile`
+
+**Path A — PRAutoClose=false:**
+- `cfg.PRAutoClose = false` → `SinkCloser.Close` NOT called even with `SinkRef` set
+
+**Path B — Succeeded job with SinkRef, finding cleared:**
+- `PhaseSucceeded` rjob with `SinkRef.URL` set → `SinkCloser.Close` called once;
+  rjob is NOT deleted (still exists after reconcile)
+
+**Path B — Succeeded job without SinkRef:**
+- `PhaseSucceeded` rjob with `SinkRef.URL == ""` → `SinkCloser.Close` NOT called
+
+**Path B — SinkCloser returns error:**
+- `SinkCloser.Close` returns error → rjob not deleted; error logged; reconcile
+  returns nil
+
+**Path B — nil SinkCloser:**
+- `r.SinkCloser = nil` → no panic; reconcile returns nil
+
+**finding == nil path triggers Path B:**
+- Object exists but `ExtractFinding` returns `(nil, nil)` + `PhaseSucceeded` rjob with
+  `SinkRef.URL` set → `SinkCloser.Close` is called (a new `r.List()` is performed
+  inside the `finding == nil` branch specifically for this case)
+
+**Old rjob (prRef only, no sinkRef):**
+- `PhaseSucceeded` rjob with `Status.PRRef = "https://..."` but `SinkRef.URL == ""` →
+  `SinkCloser.Close` NOT called
+
+**Path B idempotency across reconciles:**
+- Source object is deleted; first reconcile closes the PR (Close returns nil) ✓
+- If the reconciler fires again for the same source ref (e.g. cache resync),
+  `GitHubSinkCloser.Close` calls the GitHub API again; GitHub returns 422 (already
+  closed); closer treats 422 as success and returns nil — no spam, no error logged.
+  This is the mechanism that prevents redundant API calls across multiple reconciles.
+  Test: fake `SinkCloser` that returns nil on all calls; verify `Close` is called each
+  time but `Reconcile` returns nil and rjob is never deleted.
+
+## Files Touched
+
+| File | Change |
+|------|--------|
+| `internal/config/config.go` | Add `PRAutoClose bool` |
+| `internal/provider/provider.go` | Add `SinkCloser` field; add Path A + Path B logic; extract `autoCloseSucceededSinks` helper |
+| `internal/provider/provider_test.go` | Add test scenarios above |
+
+## TDD Sequence
+
+1. Add `PRAutoClose` to `config.Config` and `FromEnv()`; write config tests first
+2. Write provider tests for Path A and Path B — all fail
+3. Add `SinkCloser` field and Path A logic to `provider.go`
+4. Add `autoCloseSucceededSinks` and Path B call sites
+5. All provider tests pass
+6. Run full suite: `go test -timeout 30s -race ./...`

--- a/docs/BACKLOG/epic26-auto-close-resolved/STORY_04_deploy.md
+++ b/docs/BACKLOG/epic26-auto-close-resolved/STORY_04_deploy.md
@@ -1,0 +1,164 @@
+# Story 04: Deploy Manifest — Secret Mount + PR_AUTO_CLOSE
+
+## Status: Complete
+
+## Goal
+
+Mount the GitHub App credentials Secret into the watcher Deployment (Helm chart and
+any Kustomize overlays), and add the `PR_AUTO_CLOSE` and GitHub App env vars so the
+watcher can exchange App credentials for an installation token at runtime.
+
+## Background
+
+The agent Job already receives the GitHub App credentials via a Secret (`secret-github-app`)
+through env vars (`GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PRIVATE_KEY`).
+The watcher Deployment currently does NOT mount this Secret — it has no need to call
+GitHub today. After epic26, the watcher needs these credentials to auto-close PRs.
+
+The Helm chart (`charts/mendabot/templates/deployment-watcher.yaml`) is the canonical
+deployment path. Kustomize overlays in `deploy/overlays/` are secondary.
+
+## Acceptance Criteria
+
+- [x] `charts/mendabot/templates/deployment-watcher.yaml` adds:
+      - `PR_AUTO_CLOSE` env var from `values.yaml`
+      - `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PRIVATE_KEY` env
+        vars sourced from `secretRef: { name: mendabot-github-app }` (same Secret the
+        agent uses)
+- [x] `charts/mendabot/values.yaml` adds `watcher.prAutoClose: true`
+- [x] Secret mount is **required** (no `optional: true`): watcher pod will not start if
+      the Secret is absent — this is a hard misconfiguration, not a graceful degradation
+- [x] `main.go` wiring does NOT include a graceful fallback for missing credentials:
+      if the Secret is mounted (pod started), the env vars are always present; if
+      credential parsing fails, log at Error and exit non-zero (fail fast)
+- [x] `go build ./...` succeeds
+- [x] Helm template renders without errors: `helm template . | kubectl apply --dry-run=client -f -`
+
+## Implementation Notes
+
+### charts/mendabot/values.yaml
+
+Add under `watcher:`:
+
+```yaml
+  # -- Automatically close open GitHub PRs/issues when the underlying finding resolves.
+  # Set to false to disable auto-close and leave PRs open for manual review.
+  prAutoClose: true
+```
+
+### charts/mendabot/templates/deployment-watcher.yaml
+
+After the existing `DISABLE_CASCADE_CHECK` env var block, add:
+
+```yaml
+        - name: PR_AUTO_CLOSE
+          value: {{ .Values.watcher.prAutoClose | quote }}
+        envFrom:
+        - secretRef:
+            name: mendabot-github-app
+```
+
+Wait — `envFrom` must be a sibling of `env` on the container spec, not nested inside
+`env`. The correct placement is at the container level:
+
+```yaml
+      containers:
+      - name: watcher
+        image: ...
+        env:
+          ... (existing env entries) ...
+          - name: PR_AUTO_CLOSE
+            value: {{ .Values.watcher.prAutoClose | quote }}
+        envFrom:
+        - secretRef:
+            name: mendabot-github-app
+```
+
+The Secret `mendabot-github-app` must contain these keys (same as used by the agent):
+- `GITHUB_APP_ID`
+- `GITHUB_APP_INSTALLATION_ID`
+- `GITHUB_APP_PRIVATE_KEY`
+
+This is the same Secret already documented in the deploy README. No new Secret is
+created — the watcher reuses the one the agent already uses.
+
+**Required (not optional):** Do not add `optional: true`. If the Secret is missing,
+Kubernetes will keep the Pod in `Pending` with an event clearly stating the reason.
+This is the desired behaviour — a missing Secret is a misconfiguration, not a graceful
+degradation scenario.
+
+### cmd/watcher/main.go
+
+Wire up `GitHubAppTokenProvider` and `GitHubSinkCloser` after reading `cfg`.
+
+The Secret is a **required mount** — if the pod started, the env vars are always
+present. Do not implement a graceful fallback for missing credentials. If credential
+parsing fails (e.g. malformed PEM), log at Error level and exit non-zero immediately.
+A misconfigured token provider that silently falls back to a no-op would mean
+`PR_AUTO_CLOSE=true` has no visible effect, which is harder to diagnose than a
+crash-loop.
+
+```go
+// Wire GitHub App token provider and sink closer.
+// envFrom on the Deployment guarantees these vars are present when the pod starts.
+var sinkCloser domain.SinkCloser
+if cfg.PRAutoClose {
+    appID, err := strconv.ParseInt(os.Getenv("GITHUB_APP_ID"), 10, 64)
+    if err != nil || appID <= 0 {
+        setupLog.Error(err, "GITHUB_APP_ID is missing or invalid; cannot start with PR_AUTO_CLOSE=true")
+        os.Exit(1)
+    }
+    installID, err := strconv.ParseInt(os.Getenv("GITHUB_APP_INSTALLATION_ID"), 10, 64)
+    if err != nil || installID <= 0 {
+        setupLog.Error(err, "GITHUB_APP_INSTALLATION_ID is missing or invalid; cannot start with PR_AUTO_CLOSE=true")
+        os.Exit(1)
+    }
+    privKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(os.Getenv("GITHUB_APP_PRIVATE_KEY")))
+    if err != nil {
+        setupLog.Error(err, "GITHUB_APP_PRIVATE_KEY is missing or invalid; cannot start with PR_AUTO_CLOSE=true")
+        os.Exit(1)
+    }
+    sinkCloser = &sinkhub.GitHubSinkCloser{
+        TokenProvider: &igithub.GitHubAppTokenProvider{
+            AppID:          appID,
+            InstallationID: installID,
+            PrivateKey:     privKey,
+        },
+    }
+} else {
+    sinkCloser = domain.NoopSinkCloser{}
+}
+```
+
+Then pass `sinkCloser` when constructing each `SourceProviderReconciler`:
+
+```go
+SinkCloser: sinkCloser,
+```
+
+**Why no graceful fallback:** The previous draft included an `else` branch that fell
+back to `NoopSinkCloser{}` when credentials were absent even with `PR_AUTO_CLOSE=true`.
+That code was dead — if `envFrom.secretRef` has no `optional: true`, the pod never
+starts without the Secret, so the env vars are always present when the code runs. The
+fallback created a false impression of graceful degradation and masked misconfiguration.
+Fail fast; let the operator fix the Secret.
+
+## Files Touched
+
+| File | Change |
+|------|--------|
+| `charts/mendabot/templates/deployment-watcher.yaml` | Add `PR_AUTO_CLOSE` env var; add `envFrom` for GitHub App Secret |
+| `charts/mendabot/values.yaml` | Add `watcher.prAutoClose: true` |
+| `cmd/watcher/main.go` | Wire `GitHubAppTokenProvider` + `GitHubSinkCloser`; pass `SinkCloser` to reconciler |
+
+## TDD Sequence
+
+This story is primarily manifest and wiring work, not business logic. There are no
+unit tests for the YAML itself. Validate with:
+
+```bash
+helm template charts/mendabot | kubectl apply --dry-run=client -f -
+go build ./...
+```
+
+The integration is verified end-to-end in the cluster after STORY_05 lands.

--- a/docs/BACKLOG/epic26-auto-close-resolved/STORY_05_agent_sinkref_patch.md
+++ b/docs/BACKLOG/epic26-auto-close-resolved/STORY_05_agent_sinkref_patch.md
@@ -1,0 +1,154 @@
+# Story 05: Agent — Write SinkRef After gh pr create
+
+## Status: Complete
+
+## Goal
+
+After the agent opens a PR (STEP 8 in the core prompt), instruct it to capture the PR
+URL and number from `gh pr create --json url,number` output and write the structured
+`SinkRef` fields back to the `RemediationJob`'s status subresource via
+`kubectl patch`. This gives the watcher the structured data it needs to auto-close the
+PR when the finding resolves.
+
+## Background
+
+The agent currently opens a PR in STEP 8 and the PR URL is later written to
+`status.prRef` via a separate mechanism (or not at all in some flows). The `SinkRef`
+struct (added by STORY_00) requires `Type`, `URL`, `Number`, and `Repo` for REST API
+auto-close.
+
+The agent is an AI model driven by the prompt in `charts/mendabot/files/prompts/core.txt`.
+The correct mechanism to instruct the agent to write `SinkRef` is to add a new step to
+the core prompt. No entrypoint shell script changes are needed — the agent calls
+`gh pr create` as an AI tool call, not via a shell wrapper.
+
+The `RemediationJob` name is deterministic: `mendabot-<FINDING_FINGERPRINT[:12]>`.
+The agent already knows `FINDING_FINGERPRINT` from its env vars.
+The agent already has `kubectl` available and has cluster write access for status.
+
+## Acceptance Criteria
+
+- [x] `charts/mendabot/files/prompts/core.txt` has a new STEP 9 after the `gh pr create`
+      block in STEP 8
+- [x] STEP 9 instructs the agent to run `gh pr create --json url,number` (if not already
+      done) and `kubectl patch` the `RemediationJob` status with `sinkRef`
+- [x] The `kubectl patch` uses the status subresource (`--subresource=status`)
+- [x] The patch sets `status.sinkRef.type`, `status.sinkRef.url`,
+      `status.sinkRef.number`, `status.sinkRef.repo`
+- [x] STEP 9 is explicitly marked as **mandatory** (HARD RULE: if patch fails, log the
+      error but do not fail the job — the PR is already open and must not be retracted)
+- [x] STEP 9 also patches `status.prRef` for backwards compatibility with the existing
+      `kubectl get rjobs` display column
+- [x] The STEP 9 instructions cover both the "new PR opened" case and the "existing PR
+      found" case (STEP 1 in the prompt finds an existing PR → agent comments on it →
+      must still write `SinkRef` pointing to the existing PR)
+
+## Implementation Notes
+
+### core.txt STEP 9
+
+Add the following after the `gh pr create` block and PR body format section, before
+the `=== HARD RULES ===` section:
+
+```
+STEP 9 — Write SinkRef back to the RemediationJob (MANDATORY)
+
+After STEP 8 completes (either a new PR was opened or an existing PR was found and
+commented on), write the PR reference back to the RemediationJob status subresource.
+This enables the watcher to auto-close the PR when the underlying issue resolves.
+
+RJOB_NAME="mendabot-${FINDING_FINGERPRINT:0:12}"
+RJOB_NAMESPACE="${AGENT_NAMESPACE}"
+
+# Capture the PR URL and number. Use --json if you opened the PR in this step,
+# or use gh pr view if you found an existing PR in STEP 1.
+# PR_URL must be the full HTML URL (e.g. https://github.com/org/repo/pull/42).
+# PR_NUMBER must be the integer number (e.g. 42).
+# PR_REPO must be in "owner/repo" format (e.g. "lenaxia/talos-ops-prod").
+
+# Example: if you ran gh pr create --json url,number earlier:
+#   OUTPUT=$(gh pr create --repo ${GITOPS_REPO} ... --json url,number)
+#   PR_URL=$(echo "$OUTPUT" | jq -r '.url')
+#   PR_NUMBER=$(echo "$OUTPUT" | jq -r '.number')
+# If you found an existing PR in STEP 1:
+#   PR_URL=$(gh pr view --repo ${GITOPS_REPO} fix/mendabot-${FINDING_FINGERPRINT} --json url -q .url)
+#   PR_NUMBER=$(gh pr view --repo ${GITOPS_REPO} fix/mendabot-${FINDING_FINGERPRINT} --json number -q .number)
+
+PR_REPO="${GITOPS_REPO}"
+
+kubectl patch remediationjob "${RJOB_NAME}" \
+  --namespace "${RJOB_NAMESPACE}" \
+  --subresource=status \
+  --type=merge \
+  --patch "{
+    \"status\": {
+      \"prRef\": \"${PR_URL}\",
+      \"sinkRef\": {
+        \"type\": \"pr\",
+        \"url\": \"${PR_URL}\",
+        \"number\": ${PR_NUMBER},
+        \"repo\": \"${PR_REPO}\"
+      }
+    }
+  }" || echo "WARNING: failed to write SinkRef to RemediationJob — PR is still open and valid"
+
+If the kubectl patch fails, print a warning and continue. The PR is already open and
+must not be retracted. The auto-close feature will not work for this run, but the
+investigation result is preserved.
+```
+
+### Why not a shell wrapper?
+
+The agent calls `gh pr create` as an AI tool call, not as a shell command in a wrapper
+script. The entrypoint scripts (`entrypoint-opencode.sh`, `entrypoint-common.sh`) run
+`opencode run` (or `claude run`) and then exit. There is no post-agent hook available.
+The only reliable mechanism to instruct the agent to run post-PR steps is via the
+prompt.
+
+### Why --subresource=status?
+
+The `RemediationJob` type uses `+kubebuilder:subresource:status`. Updates to `status`
+fields via the main resource endpoint are silently rejected by the API server. The
+agent must use `--subresource=status` for the patch to actually persist.
+
+### Agent RBAC
+
+The agent already has `update` on `remediationjobs/status` via the agent RBAC manifests
+(added in the cascade prevention epic). Verify this before closing the story:
+
+```bash
+kubectl auth can-i update remediationjobs/status --as=system:serviceaccount:mendabot:mendabot-agent
+```
+
+If it returns `no`, add `remediationjobs/status` to the agent ClusterRole or Role.
+
+### FINDING_FINGERPRINT length
+
+`FINDING_FINGERPRINT` is a 64-character hex SHA256. The RemediationJob name is
+`mendabot-<first 12 chars>`. The `${FINDING_FINGERPRINT:0:12}` bash substring
+syntax extracts the first 12 characters. This must match the name computed in
+`internal/provider/provider.go:433` (`"mendabot-" + fp[:12]`).
+
+### AGENT_NAMESPACE env var
+
+`AGENT_NAMESPACE` is already injected into the agent Job by `internal/jobbuilder/job.go`.
+No new env vars are needed.
+
+## Files Touched
+
+| File | Change |
+|------|--------|
+| `charts/mendabot/files/prompts/core.txt` | Add STEP 9 after STEP 8 |
+
+## Verification
+
+After deploying, trigger a test finding. When the agent completes:
+
+```bash
+kubectl get rjob -n mendabot mendabot-<fp12> -o jsonpath='{.status.sinkRef}'
+```
+
+Should return a non-empty object with `type`, `url`, `number`, and `repo` populated.
+
+Then delete/resolve the source resource that triggered the finding. Within a few
+reconcile cycles, the PR should be auto-closed with a comment.

--- a/docs/WORKLOGS/0091_2026-02-26_epic26-auto-close-resolved.md
+++ b/docs/WORKLOGS/0091_2026-02-26_epic26-auto-close-resolved.md
@@ -1,0 +1,121 @@
+# Worklog 0091 — Epic 26: Auto-Close Resolved Findings
+
+**Date:** 2026-02-26
+**Branch:** `feature/epic26-auto-close-resolved`
+**Version:** v0.3.24 → v0.3.25
+
+## Summary
+
+Implemented Epic 26 end-to-end across 6 stories. When a Kubernetes finding clears
+(deployment recovers, PVC is provisioned, node returns Ready), the watcher now
+automatically closes the GitHub PR that the agent opened — both for in-flight jobs
+(Pending/Dispatched/Running) and for already-succeeded jobs whose PR became stale after
+the cluster self-healed.
+
+## Motivation
+
+Production clusters with frequent transient failures accumulated a backlog of stale PRs
+that obscured genuinely actionable ones. Humans were closing them manually. The
+`PhaseSucceeded` path (job already done, finding later clears) was the most common
+scenario and was entirely unhandled.
+
+## Changes
+
+### STORY_00 — SinkRef domain type + SinkCloser interface
+- Added `SinkRef` struct to `api/v1alpha1/remediationjob_types.go` with fields
+  `Type`, `URL`, `Number`, `Repo`
+- Added `SinkCloser` interface to `internal/domain/sink.go`
+- Added `NoopSinkCloser` for use when `PR_AUTO_CLOSE=false`
+- Updated `DeepCopyInto` in `zz_generated.deepcopy.go`
+- Added `sinkRef` to CRD testdata YAML
+
+### STORY_01 — GitHub App token provider
+- `internal/github/token_provider.go` — RS256 JWT → installation token exchange
+- 55-minute in-memory cache (refreshes before the 1-hour GitHub App expiry)
+- Mock HTTP server tests covering cache hit, cache miss, and error paths
+
+### STORY_02 — GitHubSinkCloser (REST API)
+- `internal/sink/github/closer.go` — calls GitHub REST API directly (`net/http`)
+- No `gh` CLI subprocess — watcher container does not have `gh` installed
+- `postComment` posts a human-readable closure reason; failure is a warning (non-fatal)
+- `closeItem` closes the PR/issue; HTTP 422 treated as success (already closed)
+- Validates `SinkRef.Number > 0` and `SinkRef.Repo != ""` before any API call
+
+### STORY_03 — Wire SinkCloser into SourceProviderReconciler
+- **Path A** — finding cleared, in-flight jobs: calls `SinkCloser.Close` before
+  cancelling Pending/Dispatched/Running/Suppressed jobs that have a non-empty `SinkRef.URL`
+- **Path B** — finding cleared, already-Succeeded jobs: `autoCloseSucceededSinks()`
+  helper iterates `PhaseSucceeded` rjobs matching the same `SourceResultRef` and closes
+  their sinks; does NOT delete the rjob (it remains as the dedup tombstone)
+- `SinkCloser` injected as a field on `SourceProviderReconciler`; closure failure is
+  logged and never blocks cancellation or deletion
+
+### STORY_04 — Helm chart + config
+- `internal/config/config.go` — added `PRAutoClose bool` (default `true`)
+- `charts/mendabot/values.yaml` — added `prAutoClose: true`
+- `charts/mendabot/templates/deployment-watcher.yaml` — added `PR_AUTO_CLOSE` env var
+  and `envFrom` for GitHub App Secret; Secret is **required** (no `optional: true`)
+- `charts/mendabot/values.schema.json` — added `prAutoClose` boolean field
+- `cmd/watcher/main.go` — constructs `GitHubAppTokenProvider` + `GitHubSinkCloser`
+  when `PRAutoClose=true`; falls back to `NoopSinkCloser` otherwise
+
+### STORY_05 — Agent: write SinkRef after gh pr create
+- Added STEP 9 to `charts/mendabot/files/prompts/core.txt`
+- Agent captures `PR_URL` and `PR_NUMBER` from `gh pr create --json url,number` output
+  (or `gh pr view` if finding an existing PR in STEP 1)
+- Agent runs `kubectl patch remediationjob --subresource=status` to populate
+  `status.sinkRef` and `status.prRef`; patch failure is a warning, never aborts the job
+- Agent RBAC already had `remediationjobs/status` with `patch` verb (verified in
+  `charts/mendabot/templates/role-agent.yaml`)
+
+## Test Coverage
+
+All new code covered by unit tests with mock HTTP servers. No fake environment or
+cluster required.
+
+```
+ok  github.com/lenaxia/k8s-mendabot/internal/github       (cached)
+ok  github.com/lenaxia/k8s-mendabot/internal/sink/github  (cached)
+ok  github.com/lenaxia/k8s-mendabot/internal/provider     9.917s
+ok  github.com/lenaxia/k8s-mendabot/internal/config       1.210s
+```
+
+Full suite: `go test -timeout 30s -race ./...` — all pass.
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| REST API not `gh` CLI | `gh` is absent from the watcher container |
+| 422 = success | GitHub returns 422 on already-closed PR; idempotency is required |
+| `postComment` failure is non-fatal | PR closure must not be gated on comment success |
+| `PhaseSucceeded` rjobs NOT deleted after auto-close | They serve as dedup tombstones |
+| Secret mount is required (not optional) | Pod fails fast at startup if Secret is missing |
+| `PR_AUTO_CLOSE=false` → `NoopSinkCloser` | Binary opt-out at operator level |
+| Agent writes SinkRef via prompt STEP 9 | Agent calls `gh` as AI tool; no shell hook available |
+
+## Backwards Compatibility
+
+Old `RemediationJob` objects (pre-epic26) have `status.prRef` set but
+`status.sinkRef` empty. The auto-close logic checks `SinkRef.URL != ""` — old objects
+are silently skipped. Migration is natural: old rjobs expire via TTL; new ones populate
+`SinkRef`.
+
+## Verification (post-deploy)
+
+```bash
+# After agent completes on a new finding:
+kubectl get rjob -n mendabot mendabot-<fp12> -o jsonpath='{.status.sinkRef}'
+
+# After the finding resolves, within a few reconcile cycles the PR should be closed.
+# Check for auto-close comment on the PR.
+```
+
+## Commits
+
+- `88b070e` STORY_00 — SinkRef domain type + SinkCloser interface
+- `41711e5` STORY_01 — GitHub App token provider
+- `e6903cc` STORY_02 — GitHubSinkCloser REST API implementation
+- `068847a` STORY_03 — wire SinkCloser into SourceProviderReconciler
+- `b98edd7` STORY_04 — Helm chart Secret mount + main.go SinkCloser wiring
+- `9aa90d5` STORY_05 — agent writes SinkRef after gh pr create

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -94,6 +94,7 @@ _Appears in:_
 | `Failed` | PhaseFailed means the batch/v1 Job failed (all retries exhausted or deadline exceeded).<br /> |
 | `Cancelled` | PhaseCancelled means the RemediationJob was deleted before it could complete<br />because its source Result was deleted while the job was Pending or Running.<br /> |
 | `PermanentlyFailed` | PhasePermanentlyFailed means RetryCount has reached MaxRetries.<br />The RemediationJob will never be re-dispatched. The SourceProviderReconciler<br />treats this phase as a terminal tombstone and does not delete-and-recreate.<br /> |
+| `Suppressed` | PhaseSuppressed means the RemediationJob was grouped with a correlated finding<br />and will not be dispatched independently. A separate primary job covers the group.<br /> |
 
 
 #### RemediationJobSpec
@@ -135,11 +136,13 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `phase` _[RemediationJobPhase](#remediationjobphase)_ | Phase is the current lifecycle phase of this RemediationJob. |  | Enum: [Pending Dispatched Running Succeeded Failed Cancelled PermanentlyFailed] <br /> |
+| `phase` _[RemediationJobPhase](#remediationjobphase)_ | Phase is the current lifecycle phase of this RemediationJob. |  | Enum: [Pending Dispatched Running Succeeded Failed Cancelled PermanentlyFailed Suppressed] <br /> |
 | `jobRef` _string_ | JobRef is the name of the batch/v1 Job created for this remediation.<br />Set once the Job has been created. |  |  |
 | `prRef` _string_ | PRRef is the GitHub PR URL opened or commented on by the agent.<br />Set by the agent via a status patch before it exits (best-effort). |  |  |
 | `message` _string_ | Message is a human-readable description of the current state,<br />e.g. an error message if Phase is Failed. |  |  |
 | `retryCount` _integer_ | RetryCount is the number of times the owned batch/v1 Job has entered the<br />Failed state. Incremented by RemediationJobReconciler each time the job<br />transitions to PhaseFailed. Read by SourceProviderReconciler to decide<br />whether to re-dispatch or tombstone. |  |  |
+| `correlationGroupID` _string_ | CorrelationGroupID is set when this job is part of a correlated group.<br />Empty when not correlated.<br />Design note: STORY_00 also specified RelatedFindings, CorrelationRole, and<br />CorrelationRule as spec/status fields. The implementation intentionally stores<br />these as labels (mendabot.io/correlation-group-id, mendabot.io/correlation-role)<br />and passes correlated findings as a runtime slice to dispatch() rather than<br />persisting them. The labels are searchable via kubectl and the recovery path<br />(controller.go) reconstructs AllFindings from suppressed peers on restart.<br />CorrelationGroupID here is the only status field needed for recovery. |  |  |
+| `sinkRef` _[SinkRef](#sinkref)_ | SinkRef identifies the GitHub PR or issue opened by the agent.<br />Empty until the agent writes it after opening the sink. |  | Optional: \{\} <br /> |
 
 
 #### ResultRef
@@ -157,5 +160,26 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `name` _string_ | Name is the name of the source object. |  |  |
 | `namespace` _string_ | Namespace is the namespace of the source object. |  |  |
+
+
+#### SinkRef
+
+
+
+SinkRef identifies the GitHub PR or issue opened by the agent.
+Set by the agent via a status patch after gh pr create succeeds.
+Used by the watcher to auto-close the sink when the finding resolves.
+
+
+
+_Appears in:_
+- [RemediationJobStatus](#remediationjobstatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `type` _string_ | Type is "pr" or "issue". |  |  |
+| `url` _string_ | URL is the full HTML URL (e.g. https://github.com/org/repo/pull/42).<br />Used in log messages and closure comments. |  |  |
+| `number` _integer_ | Number is the PR or issue number. Required for GitHub REST API calls. |  |  |
+| `repo` _string_ | Repo is "owner/repo" format (e.g. "lenaxia/talos-ops-prod").<br />Required for GitHub REST API calls. |  |  |
 
 

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/gnostic-models v0.6.8 h1:yo/ABAfM5IMRsS1VnXjTBvUb61tFIHozhlYvRgGre9I=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -314,25 +314,6 @@ func FromEnv() (Config, error) {
 		return Config{}, fmt.Errorf("DRY_RUN must be 'true', 'false', '1', or '0', got %q", dryRunStr)
 	}
 
-	// LLM provider selection — empty string disables the LLM readiness check.
-	// bedrock and vertex are reserved for future implementation; configuring them
-	// is a startup error rather than a silent runtime block.
-	cfg.LLMProvider = os.Getenv("LLM_PROVIDER")
-	switch cfg.LLMProvider {
-	case "", "openai":
-		// valid
-	case "bedrock", "vertex":
-		return Config{}, fmt.Errorf(
-			"LLM_PROVIDER=%q is not yet implemented; set LLM_PROVIDER=openai or leave it unset to disable the LLM readiness check",
-			cfg.LLMProvider,
-		)
-	default:
-		return Config{}, fmt.Errorf(
-			"LLM_PROVIDER %q is not supported; accepted values: openai (or unset to disable)",
-			cfg.LLMProvider,
-		)
-	}
-
 	// Correlation window — how long to hold Pending jobs before dispatching.
 	// Must be at least as long as stabilization window to allow related findings to be grouped.
 	// Design invariant: CORRELATION_WINDOW >= STABILISATION_WINDOW

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,6 +74,10 @@ type Config struct {
 	// MultiPodThreshold is the minimum number of pod findings on the same node
 	// required for MultiPodSameNodeRule to fire.
 	MultiPodThreshold int // CORRELATION_MULTI_POD_THRESHOLD — default 3
+
+	// PRAutoClose controls whether open sinks are auto-closed when a finding resolves.
+	// Default: true. Set PR_AUTO_CLOSE=false to disable.
+	PRAutoClose bool // PR_AUTO_CLOSE — default true
 }
 
 // FromEnv reads configuration from environment variables and returns a Config.
@@ -334,7 +338,7 @@ func FromEnv() (Config, error) {
 	// Design invariant: CORRELATION_WINDOW >= STABILISATION_WINDOW
 	corrWindowStr := os.Getenv("CORRELATION_WINDOW_SECONDS")
 	if corrWindowStr == "" {
-		cfg.CorrelationWindowSeconds = int(cfg.StabilisationWindow.Seconds())
+		cfg.CorrelationWindowSeconds = 30
 	} else {
 		n, err := strconv.Atoi(corrWindowStr)
 		if err != nil {
@@ -366,6 +370,17 @@ func FromEnv() (Config, error) {
 			return Config{}, fmt.Errorf("CORRELATION_MULTI_POD_THRESHOLD must be a positive integer, got %d", n)
 		}
 		cfg.MultiPodThreshold = n
+	}
+
+	// PR_AUTO_CLOSE — default true; set "false" or "0" to disable sink auto-close.
+	prAutoCloseStr := os.Getenv("PR_AUTO_CLOSE")
+	switch prAutoCloseStr {
+	case "", "true", "1":
+		cfg.PRAutoClose = true
+	case "false", "0":
+		cfg.PRAutoClose = false
+	default:
+		return Config{}, fmt.Errorf("PR_AUTO_CLOSE must be 'true', 'false', '1', or '0', got %q", prAutoCloseStr)
 	}
 
 	return cfg, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1590,3 +1590,70 @@ func TestFromEnv_CorrelationWindowNegative(t *testing.T) {
 		t.Fatal("expected error for CORRELATION_WINDOW_SECONDS=-1, got nil")
 	}
 }
+
+// TestFromEnv_PRAutoClose_DefaultTrue verifies PR_AUTO_CLOSE defaults to true.
+func TestFromEnv_PRAutoClose_DefaultTrue(t *testing.T) {
+	setRequiredEnv(t)
+	os.Unsetenv("PR_AUTO_CLOSE")
+
+	cfg, err := config.FromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.PRAutoClose {
+		t.Error("expected PRAutoClose=true by default, got false")
+	}
+}
+
+// TestFromEnv_PRAutoClose_ExplicitTrue verifies PR_AUTO_CLOSE=true parses correctly.
+func TestFromEnv_PRAutoClose_ExplicitTrue(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("PR_AUTO_CLOSE", "true")
+
+	cfg, err := config.FromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.PRAutoClose {
+		t.Error("expected PRAutoClose=true, got false")
+	}
+}
+
+// TestFromEnv_PRAutoClose_False verifies PR_AUTO_CLOSE=false disables auto-close.
+func TestFromEnv_PRAutoClose_False(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("PR_AUTO_CLOSE", "false")
+
+	cfg, err := config.FromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.PRAutoClose {
+		t.Error("expected PRAutoClose=false, got true")
+	}
+}
+
+// TestFromEnv_PRAutoClose_Zero verifies PR_AUTO_CLOSE=0 disables auto-close.
+func TestFromEnv_PRAutoClose_Zero(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("PR_AUTO_CLOSE", "0")
+
+	cfg, err := config.FromEnv()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.PRAutoClose {
+		t.Error("expected PRAutoClose=false for PR_AUTO_CLOSE=0, got true")
+	}
+}
+
+// TestFromEnv_PRAutoClose_InvalidValue verifies invalid PR_AUTO_CLOSE returns an error.
+func TestFromEnv_PRAutoClose_InvalidValue(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("PR_AUTO_CLOSE", "yes")
+
+	_, err := config.FromEnv()
+	if err == nil {
+		t.Fatal("expected error for PR_AUTO_CLOSE=yes, got nil")
+	}
+}

--- a/internal/domain/sink.go
+++ b/internal/domain/sink.go
@@ -1,0 +1,22 @@
+package domain
+
+import (
+	"context"
+
+	v1alpha1 "github.com/lenaxia/k8s-mendabot/api/v1alpha1"
+)
+
+// SinkCloser closes an open sink (PR or issue) when the underlying finding resolves.
+// Implementations must be idempotent: closing an already-closed sink returns nil.
+// Close returns nil immediately if rjob.Status.SinkRef.URL is empty.
+type SinkCloser interface {
+	Close(ctx context.Context, rjob *v1alpha1.RemediationJob, reason string) error
+}
+
+// NoopSinkCloser is a SinkCloser that does nothing.
+// Used when PR_AUTO_CLOSE=false or in tests that do not need real closure.
+type NoopSinkCloser struct{}
+
+func (NoopSinkCloser) Close(_ context.Context, _ *v1alpha1.RemediationJob, _ string) error {
+	return nil
+}

--- a/internal/domain/sink_test.go
+++ b/internal/domain/sink_test.go
@@ -1,0 +1,75 @@
+package domain_test
+
+import (
+	"context"
+	"testing"
+
+	v1alpha1 "github.com/lenaxia/k8s-mendabot/api/v1alpha1"
+	"github.com/lenaxia/k8s-mendabot/internal/domain"
+)
+
+// Compile-time interface satisfaction check.
+var _ domain.SinkCloser = domain.NoopSinkCloser{}
+
+func TestNoopSinkCloser_AlwaysNil(t *testing.T) {
+	t.Parallel()
+	closer := domain.NoopSinkCloser{}
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		rjob *v1alpha1.RemediationJob
+	}{
+		{
+			name: "empty SinkRef",
+			rjob: &v1alpha1.RemediationJob{},
+		},
+		{
+			name: "fully populated SinkRef",
+			rjob: &v1alpha1.RemediationJob{
+				Status: v1alpha1.RemediationJobStatus{
+					SinkRef: v1alpha1.SinkRef{
+						Type:   "pr",
+						URL:    "https://github.com/org/repo/pull/42",
+						Number: 42,
+						Repo:   "org/repo",
+					},
+				},
+			},
+		},
+		{
+			name: "partial SinkRef (URL only)",
+			rjob: &v1alpha1.RemediationJob{
+				Status: v1alpha1.RemediationJobStatus{
+					SinkRef: v1alpha1.SinkRef{
+						URL: "https://github.com/org/repo/pull/99",
+					},
+				},
+			},
+		},
+		{
+			name: "nil rjob-like zero value",
+			rjob: &v1alpha1.RemediationJob{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if err := closer.Close(ctx, tc.rjob, "some reason"); err != nil {
+				t.Errorf("NoopSinkCloser.Close() returned non-nil error: %v", err)
+			}
+		})
+	}
+}
+
+func TestNoopSinkCloser_NilContextOK(t *testing.T) {
+	t.Parallel()
+	// NoopSinkCloser must not dereference ctx, so nil context is safe.
+	closer := domain.NoopSinkCloser{}
+	//nolint:staticcheck // deliberate nil context test
+	err := closer.Close(nil, &v1alpha1.RemediationJob{}, "reason") //nolint:staticcheck
+	if err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+}

--- a/internal/github/token.go
+++ b/internal/github/token.go
@@ -1,0 +1,114 @@
+package github
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const tokenCacheTTL = 55 * time.Minute
+
+// TokenProvider returns a valid GitHub installation token.
+// Implementations are safe for concurrent use.
+type TokenProvider interface {
+	Token(ctx context.Context) (string, error)
+}
+
+// GitHubAppTokenProvider exchanges a GitHub App private key for installation tokens.
+// Tokens are cached for 55 minutes and re-exchanged automatically.
+type GitHubAppTokenProvider struct {
+	AppID          int64
+	InstallationID int64
+	PrivateKey     *rsa.PrivateKey
+	// BaseURL allows overriding the GitHub API endpoint in tests.
+	// Defaults to "https://api.github.com" when empty.
+	BaseURL    string
+	HTTPClient *http.Client
+
+	mu          sync.Mutex
+	cachedToken string
+	expiresAt   time.Time
+}
+
+// Token returns a valid installation token, using the cache when possible.
+func (p *GitHubAppTokenProvider) Token(ctx context.Context) (string, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.cachedToken != "" && time.Now().Before(p.expiresAt) {
+		return p.cachedToken, nil
+	}
+	tok, err := p.exchange(ctx)
+	if err != nil {
+		return "", err
+	}
+	p.cachedToken = tok
+	p.expiresAt = time.Now().Add(tokenCacheTTL)
+	return tok, nil
+}
+
+// ForceExpiry expires the cached token immediately, forcing a re-exchange on the
+// next Token() call. Used only in tests.
+func (p *GitHubAppTokenProvider) ForceExpiry() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.expiresAt = time.Now().Add(-time.Second)
+}
+
+func (p *GitHubAppTokenProvider) exchange(ctx context.Context) (string, error) {
+	// 1. Mint a JWT valid for 10 minutes.
+	now := time.Now()
+	claims := jwt.RegisteredClaims{
+		IssuedAt:  jwt.NewNumericDate(now.Add(-60 * time.Second)), // 60s clock skew buffer
+		ExpiresAt: jwt.NewNumericDate(now.Add(10 * time.Minute)),
+		Issuer:    fmt.Sprintf("%d", p.AppID),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	signed, err := token.SignedString(p.PrivateKey)
+	if err != nil {
+		return "", fmt.Errorf("signing JWT: %w", err)
+	}
+
+	// 2. Exchange JWT for installation token.
+	base := p.BaseURL
+	if base == "" {
+		base = "https://api.github.com"
+	}
+	url := fmt.Sprintf("%s/app/installations/%d/access_tokens", base, p.InstallationID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("building token request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+signed)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	hc := p.HTTPClient
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("token exchange request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("token exchange: unexpected status %d", resp.StatusCode)
+	}
+
+	var body struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", fmt.Errorf("decoding token response: %w", err)
+	}
+	if body.Token == "" {
+		return "", fmt.Errorf("token exchange: empty token in response")
+	}
+	return body.Token, nil
+}

--- a/internal/github/token_test.go
+++ b/internal/github/token_test.go
@@ -1,0 +1,273 @@
+package github_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	igithub "github.com/lenaxia/k8s-mendabot/internal/github"
+)
+
+// generateTestKey creates a small RSA key suitable for unit tests only.
+func generateTestKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating RSA key: %v", err)
+	}
+	return key
+}
+
+// newMockTokenServer returns an httptest server that responds to the installation
+// access_tokens endpoint. If statusCode != 201 it returns that code with no body.
+// If token is empty and statusCode == 201 it returns `{"token":""}`.
+func newMockTokenServer(t *testing.T, token string, statusCode int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if statusCode != http.StatusCreated {
+			w.WriteHeader(statusCode)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"token": token})
+	}))
+}
+
+func TestGitHubAppTokenProvider_HappyPath(t *testing.T) {
+	t.Parallel()
+	srv := newMockTokenServer(t, "ghs_test_token", http.StatusCreated)
+	defer srv.Close()
+
+	p := &igithub.GitHubAppTokenProvider{
+		AppID:          1,
+		InstallationID: 2,
+		PrivateKey:     generateTestKey(t),
+		BaseURL:        srv.URL,
+		HTTPClient:     srv.Client(),
+	}
+
+	tok, err := p.Token(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok != "ghs_test_token" {
+		t.Errorf("expected 'ghs_test_token', got %q", tok)
+	}
+}
+
+func TestGitHubAppTokenProvider_CachesToken(t *testing.T) {
+	t.Parallel()
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"token": "cached_token"})
+	}))
+	defer srv.Close()
+
+	p := &igithub.GitHubAppTokenProvider{
+		AppID:          1,
+		InstallationID: 2,
+		PrivateKey:     generateTestKey(t),
+		BaseURL:        srv.URL,
+		HTTPClient:     srv.Client(),
+	}
+
+	// First call — should hit the server.
+	tok1, err := p.Token(context.Background())
+	if err != nil {
+		t.Fatalf("first call error: %v", err)
+	}
+	// Second call — must NOT hit the server.
+	tok2, err := p.Token(context.Background())
+	if err != nil {
+		t.Fatalf("second call error: %v", err)
+	}
+	if tok1 != tok2 {
+		t.Errorf("tokens differ: %q vs %q", tok1, tok2)
+	}
+	if n := atomic.LoadInt32(&callCount); n != 1 {
+		t.Errorf("expected exactly 1 server call, got %d", n)
+	}
+}
+
+func TestGitHubAppTokenProvider_RefreshesOnExpiry(t *testing.T) {
+	t.Parallel()
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"token": "token_" + string(rune('A'+n-1))})
+	}))
+	defer srv.Close()
+
+	p := &igithub.GitHubAppTokenProvider{
+		AppID:          1,
+		InstallationID: 2,
+		PrivateKey:     generateTestKey(t),
+		BaseURL:        srv.URL,
+		HTTPClient:     srv.Client(),
+	}
+
+	// Prime the cache.
+	_, err := p.Token(context.Background())
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+
+	// Force expiry by setting ExpiresAt to the past.
+	p.ForceExpiry()
+
+	// Second call after expiry must hit the server again.
+	tok2, err := p.Token(context.Background())
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if n := atomic.LoadInt32(&callCount); n != 2 {
+		t.Errorf("expected 2 server calls, got %d", n)
+	}
+	_ = tok2
+}
+
+func TestGitHubAppTokenProvider_Non201Error(t *testing.T) {
+	t.Parallel()
+	srv := newMockTokenServer(t, "", http.StatusForbidden)
+	defer srv.Close()
+
+	p := &igithub.GitHubAppTokenProvider{
+		AppID:          1,
+		InstallationID: 2,
+		PrivateKey:     generateTestKey(t),
+		BaseURL:        srv.URL,
+		HTTPClient:     srv.Client(),
+	}
+
+	_, err := p.Token(context.Background())
+	if err == nil {
+		t.Fatal("expected error for 403 response, got nil")
+	}
+}
+
+func TestGitHubAppTokenProvider_EmptyTokenInResponse(t *testing.T) {
+	t.Parallel()
+	srv := newMockTokenServer(t, "", http.StatusCreated)
+	defer srv.Close()
+
+	p := &igithub.GitHubAppTokenProvider{
+		AppID:          1,
+		InstallationID: 2,
+		PrivateKey:     generateTestKey(t),
+		BaseURL:        srv.URL,
+		HTTPClient:     srv.Client(),
+	}
+
+	_, err := p.Token(context.Background())
+	if err == nil {
+		t.Fatal("expected error for empty token, got nil")
+	}
+}
+
+func TestGitHubAppTokenProvider_MalformedJSON(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	p := &igithub.GitHubAppTokenProvider{
+		AppID:          1,
+		InstallationID: 2,
+		PrivateKey:     generateTestKey(t),
+		BaseURL:        srv.URL,
+		HTTPClient:     srv.Client(),
+	}
+
+	_, err := p.Token(context.Background())
+	if err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+}
+
+func TestGitHubAppTokenProvider_CancelledContext(t *testing.T) {
+	t.Parallel()
+	// Server that blocks until test is done — context cancellation should fire first.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(5 * time.Second)
+	}))
+	defer srv.Close()
+
+	p := &igithub.GitHubAppTokenProvider{
+		AppID:          1,
+		InstallationID: 2,
+		PrivateKey:     generateTestKey(t),
+		BaseURL:        srv.URL,
+		HTTPClient:     srv.Client(),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := p.Token(ctx)
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+}
+
+func TestGitHubAppTokenProvider_ConcurrentCallsSingleExchange(t *testing.T) {
+	t.Parallel()
+	var callCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Small sleep to make the race window wider.
+		time.Sleep(20 * time.Millisecond)
+		atomic.AddInt32(&callCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"token": "concurrent_token"})
+	}))
+	defer srv.Close()
+
+	p := &igithub.GitHubAppTokenProvider{
+		AppID:          1,
+		InstallationID: 2,
+		PrivateKey:     generateTestKey(t),
+		BaseURL:        srv.URL,
+		HTTPClient:     srv.Client(),
+	}
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+	errs := make([]error, goroutines)
+	tokens := make([]string, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			tok, err := p.Token(context.Background())
+			errs[idx] = err
+			tokens[idx] = tok
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: unexpected error: %v", i, err)
+		}
+	}
+	// Due to mutex, exactly 1 exchange should have fired.
+	if n := atomic.LoadInt32(&callCount); n != 1 {
+		t.Errorf("expected exactly 1 server call with concurrent goroutines, got %d", n)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -41,8 +41,11 @@ type SourceProviderReconciler struct {
 	// between successive self-remediation attempts. Only consulted when
 	// finding.ChainDepth > 0. A nil value disables the circuit breaker.
 	CircuitBreaker circuitbreaker.Gater
-	firstSeen      *BoundedMap
-	initOnce       sync.Once
+	// SinkCloser closes open GitHub sinks when a finding resolves.
+	// nil disables auto-close (equivalent to PR_AUTO_CLOSE=false).
+	SinkCloser domain.SinkCloser
+	firstSeen  *BoundedMap
+	initOnce   sync.Once
 }
 
 // ReadinessCacheTTL is the recommended TTL for CachedChecker wrappers around
@@ -99,6 +102,25 @@ func (r *SourceProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				phase != v1alpha1.PhaseRunning && phase != v1alpha1.PhaseSuppressed && phase != "" {
 				continue
 			}
+			// Path A: auto-close the sink before cancellation so we still have the
+			// full rjob status available (SinkRef is cleared after deletion).
+			// Failure is non-fatal — log and proceed with cancellation.
+			if r.Cfg.PRAutoClose && r.SinkCloser != nil && rjob.Status.SinkRef.URL != "" {
+				closeReason := fmt.Sprintf(
+					"Closing automatically: the underlying issue (%s/%s %s) has resolved. No manual fix is required.",
+					rjob.Spec.Finding.Kind, rjob.Spec.Finding.Name, rjob.Spec.Finding.Namespace)
+				if closeErr := r.SinkCloser.Close(ctx, rjob, closeReason); closeErr != nil {
+					if r.Log != nil {
+						r.Log.Error("auto-close sink failed; continuing with cancellation",
+							zap.Bool("audit", true),
+							zap.String("event", "sink.close_failed"),
+							zap.String("remediationJob", rjob.Name),
+							zap.String("sinkURL", rjob.Status.SinkRef.URL),
+							zap.Error(closeErr),
+						)
+					}
+				}
+			}
 			// Patch phase to Cancelled before deleting so observers see the terminal state.
 			rjobCopy := rjob.DeepCopyObject().(*v1alpha1.RemediationJob)
 			rjob.Status.Phase = v1alpha1.PhaseCancelled
@@ -127,6 +149,12 @@ func (r *SourceProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		if len(cancelErrs) > 0 {
 			return ctrl.Result{}, fmt.Errorf("cancelling RemediationJobs: %w", errors.Join(cancelErrs...))
 		}
+		// Path B: auto-close any PhaseSucceeded sinks for this source ref.
+		// Reuses the rjobList already fetched above (full AgentNamespace scope).
+		// Do NOT delete Succeeded rjobs — they are the dedup tombstone.
+		if r.Cfg.PRAutoClose && r.SinkCloser != nil {
+			r.autoCloseSucceededSinks(ctx, req.Name, req.Namespace, &rjobList)
+		}
 		return ctrl.Result{}, nil
 	}
 
@@ -138,6 +166,18 @@ func (r *SourceProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		r.firstSeen.Clear()
 		if r.EventRecorder != nil {
 			r.EventRecorder.Event(obj, corev1.EventTypeNormal, "FindingCleared", "Finding cleared; no active finding on this object")
+		}
+		// Path B: auto-close Succeeded sinks for this source ref.
+		// Only pay the List cost when auto-close is enabled.
+		if r.Cfg.PRAutoClose && r.SinkCloser != nil {
+			var rjobList v1alpha1.RemediationJobList
+			if listErr := r.List(ctx, &rjobList, client.InNamespace(r.Cfg.AgentNamespace)); listErr == nil {
+				r.autoCloseSucceededSinks(ctx, req.Name, req.Namespace, &rjobList)
+			} else if r.Log != nil {
+				r.Log.Error("auto-close: failed to list rjobs for finding-cleared path",
+					zap.Error(listErr),
+				)
+			}
 		}
 		return ctrl.Result{}, nil
 	}
@@ -510,4 +550,50 @@ func (r *SourceProviderReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(r.Provider.ObjectType()).
 		Complete(r)
+}
+
+// autoCloseSucceededSinks iterates rjobList (which must cover the full
+// AgentNamespace — do not scope it to a single source ref before passing it in,
+// the helper filters internally) and calls SinkCloser.Close on every
+// PhaseSucceeded job whose SourceResultRef matches sourceRefName/Namespace and
+// whose SinkRef.URL is non-empty.
+//
+// The caller is responsible for guarding with PRAutoClose and SinkCloser nil
+// checks before invoking this method.
+//
+// Succeeded rjobs are intentionally NOT deleted — they are the dedup tombstone.
+// Removing them would allow re-dispatch before TTL expires.
+//
+// Successive calls for the same source ref are idempotent: GitHubSinkCloser
+// treats GitHub's 422 (already-closed) as success, so no API spam occurs on
+// repeated reconciles.
+func (r *SourceProviderReconciler) autoCloseSucceededSinks(
+	ctx context.Context,
+	sourceRefName, sourceRefNamespace string,
+	rjobList *v1alpha1.RemediationJobList,
+) {
+	for i := range rjobList.Items {
+		rjob := &rjobList.Items[i]
+		if rjob.Spec.SourceResultRef.Name != sourceRefName ||
+			rjob.Spec.SourceResultRef.Namespace != sourceRefNamespace {
+			continue
+		}
+		if rjob.Status.Phase != v1alpha1.PhaseSucceeded || rjob.Status.SinkRef.URL == "" {
+			continue
+		}
+		reason := fmt.Sprintf(
+			"Closing automatically: the underlying issue (%s/%s %s) has resolved. No manual fix is required.",
+			rjob.Spec.Finding.Kind, rjob.Spec.Finding.Name, rjob.Spec.Finding.Namespace)
+		if err := r.SinkCloser.Close(ctx, rjob, reason); err != nil {
+			if r.Log != nil {
+				r.Log.Error("auto-close succeeded sink failed",
+					zap.Bool("audit", true),
+					zap.String("event", "sink.close_succeeded_failed"),
+					zap.String("remediationJob", rjob.Name),
+					zap.String("sinkURL", rjob.Status.SinkRef.URL),
+					zap.Error(err),
+				)
+			}
+		}
+	}
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -3142,3 +3142,406 @@ func TestAuditLog_SelfRemediation_CircuitBreaker(t *testing.T) {
 		t.Errorf("expected audit log entry with event=self_remediation.circuit_breaker, got entries: %v", logs.All())
 	}
 }
+
+// ===========================================================================
+// Epic 26: Auto-close sink tests
+// ===========================================================================
+
+// fakeSinkCloser records calls and can be configured to return an error.
+type fakeSinkCloser struct {
+	calls []closeCall
+	err   error
+}
+
+type closeCall struct {
+	rjobName string
+	sinkURL  string
+	reason   string
+}
+
+func (f *fakeSinkCloser) Close(_ context.Context, rjob *v1alpha1.RemediationJob, reason string) error {
+	f.calls = append(f.calls, closeCall{
+		rjobName: rjob.Name,
+		sinkURL:  rjob.Status.SinkRef.URL,
+		reason:   reason,
+	})
+	return f.err
+}
+
+var _ domain.SinkCloser = (*fakeSinkCloser)(nil)
+
+func newAutoCloseReconciler(p *fakeSourceProvider, c client.Client, closer domain.SinkCloser, prAutoClose bool) *provider.SourceProviderReconciler {
+	return &provider.SourceProviderReconciler{
+		Client: c,
+		Scheme: newTestScheme(),
+		Cfg: config.Config{
+			AgentNamespace: agentNamespace,
+			MinSeverity:    domain.SeverityLow,
+			PRAutoClose:    prAutoClose,
+		},
+		Provider:   p,
+		SinkCloser: closer,
+	}
+}
+
+func makeSinkRef(url string) v1alpha1.SinkRef {
+	return v1alpha1.SinkRef{
+		Type:   "pr",
+		URL:    url,
+		Number: 42,
+		Repo:   "org/repo",
+	}
+}
+
+// TestAutoClose_PathA_InFlightJobWithSinkRef verifies that when a source object
+// is deleted (IsNotFound) and there is a Pending rjob with a SinkRef, the
+// SinkCloser is called before cancellation.
+func TestAutoClose_PathA_InFlightJobWithSinkRef(t *testing.T) {
+	t.Parallel()
+	rjob := &v1alpha1.RemediationJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "mendabot-aaa111", Namespace: agentNamespace},
+		Spec: v1alpha1.RemediationJobSpec{
+			SourceResultRef: v1alpha1.ResultRef{Name: "svc-a", Namespace: "default"},
+			Fingerprint:     "aaa111bbb222ccc333",
+			SourceType:      "native",
+			SinkType:        "github",
+			Finding:         v1alpha1.FindingSpec{Kind: "Deployment", Name: "svc-a", Namespace: "default"},
+			GitOpsRepo:      "org/repo",
+			AgentImage:      "img",
+			AgentSA:         "sa",
+		},
+		Status: v1alpha1.RemediationJobStatus{
+			Phase:   v1alpha1.PhasePending,
+			SinkRef: makeSinkRef("https://github.com/org/repo/pull/42"),
+		},
+	}
+	// Object is NOT in the client — triggers IsNotFound path.
+	c := newTestClient(rjob)
+
+	closer := &fakeSinkCloser{}
+	p := &fakeSourceProvider{name: "fake", objectType: &corev1.ConfigMap{}}
+	r := newAutoCloseReconciler(p, c, closer, true)
+
+	_, err := r.Reconcile(context.Background(), reqFor("svc-a", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(closer.calls) != 1 {
+		t.Fatalf("expected 1 SinkCloser.Close call, got %d", len(closer.calls))
+	}
+	if closer.calls[0].sinkURL != "https://github.com/org/repo/pull/42" {
+		t.Errorf("unexpected sinkURL: %q", closer.calls[0].sinkURL)
+	}
+}
+
+// TestAutoClose_PathA_InFlightJobWithoutSinkRef verifies that a Pending rjob
+// with empty SinkRef does NOT trigger SinkCloser.
+func TestAutoClose_PathA_InFlightJobWithoutSinkRef(t *testing.T) {
+	t.Parallel()
+	rjob := &v1alpha1.RemediationJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "mendabot-aaa222", Namespace: agentNamespace},
+		Spec: v1alpha1.RemediationJobSpec{
+			SourceResultRef: v1alpha1.ResultRef{Name: "svc-b", Namespace: "default"},
+			Fingerprint:     "aaa222bbb333ccc444",
+			SourceType:      "native",
+			SinkType:        "github",
+			Finding:         v1alpha1.FindingSpec{Kind: "Deployment", Name: "svc-b", Namespace: "default"},
+			GitOpsRepo:      "org/repo",
+			AgentImage:      "img",
+			AgentSA:         "sa",
+		},
+		Status: v1alpha1.RemediationJobStatus{
+			Phase: v1alpha1.PhasePending,
+			// SinkRef is empty (no PR opened yet)
+		},
+	}
+	c := newTestClient(rjob)
+
+	closer := &fakeSinkCloser{}
+	p := &fakeSourceProvider{name: "fake", objectType: &corev1.ConfigMap{}}
+	r := newAutoCloseReconciler(p, c, closer, true)
+
+	_, err := r.Reconcile(context.Background(), reqFor("svc-b", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(closer.calls) != 0 {
+		t.Errorf("expected 0 SinkCloser.Close calls, got %d", len(closer.calls))
+	}
+}
+
+// TestAutoClose_PathA_SinkCloserError_CancellationProceeds verifies that a
+// SinkCloser error does not block rjob cancellation.
+func TestAutoClose_PathA_SinkCloserError_CancellationProceeds(t *testing.T) {
+	t.Parallel()
+	rjob := &v1alpha1.RemediationJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "mendabot-aaa333", Namespace: agentNamespace},
+		Spec: v1alpha1.RemediationJobSpec{
+			SourceResultRef: v1alpha1.ResultRef{Name: "svc-c", Namespace: "default"},
+			Fingerprint:     "aaa333bbb444ccc555",
+			SourceType:      "native",
+			SinkType:        "github",
+			Finding:         v1alpha1.FindingSpec{Kind: "Deployment", Name: "svc-c", Namespace: "default"},
+			GitOpsRepo:      "org/repo",
+			AgentImage:      "img",
+			AgentSA:         "sa",
+		},
+		Status: v1alpha1.RemediationJobStatus{
+			Phase:   v1alpha1.PhasePending,
+			SinkRef: makeSinkRef("https://github.com/org/repo/pull/43"),
+		},
+	}
+	c := newTestClient(rjob)
+
+	closer := &fakeSinkCloser{err: errors.New("github unavailable")}
+	p := &fakeSourceProvider{name: "fake", objectType: &corev1.ConfigMap{}}
+	r := newAutoCloseReconciler(p, c, closer, true)
+
+	result, err := r.Reconcile(context.Background(), reqFor("svc-c", "default"))
+	// Reconcile must return nil — closer failure is non-fatal.
+	if err != nil {
+		t.Fatalf("expected nil error despite SinkCloser failure, got: %v", err)
+	}
+	_ = result
+
+	// Close was still called.
+	if len(closer.calls) != 1 {
+		t.Errorf("expected 1 Close call, got %d", len(closer.calls))
+	}
+}
+
+// TestAutoClose_PathA_PRAutoCloseFalse_NoClose verifies that PRAutoClose=false
+// prevents Path A from calling SinkCloser.
+func TestAutoClose_PathA_PRAutoCloseFalse_NoClose(t *testing.T) {
+	t.Parallel()
+	rjob := &v1alpha1.RemediationJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "mendabot-aaa444", Namespace: agentNamespace},
+		Spec: v1alpha1.RemediationJobSpec{
+			SourceResultRef: v1alpha1.ResultRef{Name: "svc-d", Namespace: "default"},
+			Fingerprint:     "aaa444bbb555ccc666",
+			SourceType:      "native",
+			SinkType:        "github",
+			Finding:         v1alpha1.FindingSpec{Kind: "Deployment", Name: "svc-d", Namespace: "default"},
+			GitOpsRepo:      "org/repo",
+			AgentImage:      "img",
+			AgentSA:         "sa",
+		},
+		Status: v1alpha1.RemediationJobStatus{
+			Phase:   v1alpha1.PhasePending,
+			SinkRef: makeSinkRef("https://github.com/org/repo/pull/44"),
+		},
+	}
+	c := newTestClient(rjob)
+
+	closer := &fakeSinkCloser{}
+	p := &fakeSourceProvider{name: "fake", objectType: &corev1.ConfigMap{}}
+	r := newAutoCloseReconciler(p, c, closer, false) // PRAutoClose=false
+
+	_, err := r.Reconcile(context.Background(), reqFor("svc-d", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(closer.calls) != 0 {
+		t.Errorf("expected 0 Close calls with PRAutoClose=false, got %d", len(closer.calls))
+	}
+}
+
+// TestAutoClose_PathB_SucceededJobWithSinkRef verifies that when a source object
+// exists but has no finding (finding=nil), a PhaseSucceeded rjob with SinkRef
+// gets its sink closed. The rjob must NOT be deleted.
+func TestAutoClose_PathB_SucceededJobWithSinkRef(t *testing.T) {
+	t.Parallel()
+	obj := makeWatchedObject("svc-e", "default")
+	rjob := &v1alpha1.RemediationJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "mendabot-aaa555", Namespace: agentNamespace},
+		Spec: v1alpha1.RemediationJobSpec{
+			SourceResultRef: v1alpha1.ResultRef{Name: "svc-e", Namespace: "default"},
+			Fingerprint:     "aaa555bbb666ccc777",
+			SourceType:      "native",
+			SinkType:        "github",
+			Finding:         v1alpha1.FindingSpec{Kind: "Deployment", Name: "svc-e", Namespace: "default"},
+			GitOpsRepo:      "org/repo",
+			AgentImage:      "img",
+			AgentSA:         "sa",
+		},
+		Status: v1alpha1.RemediationJobStatus{
+			Phase:   v1alpha1.PhaseSucceeded,
+			SinkRef: makeSinkRef("https://github.com/org/repo/pull/45"),
+		},
+	}
+	c := newTestClient(obj, rjob)
+
+	closer := &fakeSinkCloser{}
+	p := &fakeSourceProvider{
+		name:       "fake",
+		objectType: &corev1.ConfigMap{},
+		finding:    nil, // no finding → cleared path
+	}
+	r := newAutoCloseReconciler(p, c, closer, true)
+
+	_, err := r.Reconcile(context.Background(), reqFor("svc-e", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(closer.calls) != 1 {
+		t.Fatalf("expected 1 Close call, got %d", len(closer.calls))
+	}
+	if closer.calls[0].sinkURL != "https://github.com/org/repo/pull/45" {
+		t.Errorf("unexpected sinkURL: %q", closer.calls[0].sinkURL)
+	}
+
+	// rjob must NOT be deleted — it is the dedup tombstone.
+	var remaining v1alpha1.RemediationJob
+	if err := c.Get(context.Background(), types.NamespacedName{Name: rjob.Name, Namespace: agentNamespace}, &remaining); err != nil {
+		t.Errorf("rjob should still exist after auto-close, got error: %v", err)
+	}
+}
+
+// TestAutoClose_PathB_SucceededJobWithoutSinkRef verifies that a PhaseSucceeded
+// rjob with empty SinkRef does NOT trigger SinkCloser.
+func TestAutoClose_PathB_SucceededJobWithoutSinkRef(t *testing.T) {
+	t.Parallel()
+	obj := makeWatchedObject("svc-f", "default")
+	rjob := &v1alpha1.RemediationJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "mendabot-aaa666", Namespace: agentNamespace},
+		Spec: v1alpha1.RemediationJobSpec{
+			SourceResultRef: v1alpha1.ResultRef{Name: "svc-f", Namespace: "default"},
+			Fingerprint:     "aaa666bbb777ccc888",
+			SourceType:      "native",
+			SinkType:        "github",
+			Finding:         v1alpha1.FindingSpec{Kind: "Deployment"},
+			GitOpsRepo:      "org/repo",
+			AgentImage:      "img",
+			AgentSA:         "sa",
+		},
+		Status: v1alpha1.RemediationJobStatus{
+			Phase: v1alpha1.PhaseSucceeded,
+			// SinkRef empty — old pre-epic26 rjob
+		},
+	}
+	c := newTestClient(obj, rjob)
+	closer := &fakeSinkCloser{}
+	p := &fakeSourceProvider{name: "fake", objectType: &corev1.ConfigMap{}, finding: nil}
+	r := newAutoCloseReconciler(p, c, closer, true)
+
+	_, err := r.Reconcile(context.Background(), reqFor("svc-f", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(closer.calls) != 0 {
+		t.Errorf("expected 0 Close calls for rjob without SinkRef, got %d", len(closer.calls))
+	}
+}
+
+// TestAutoClose_PathB_SinkCloserError_RJobNotDeleted verifies that when
+// SinkCloser returns an error, the rjob is still not deleted and Reconcile
+// returns nil.
+func TestAutoClose_PathB_SinkCloserError_RJobNotDeleted(t *testing.T) {
+	t.Parallel()
+	obj := makeWatchedObject("svc-g", "default")
+	rjob := &v1alpha1.RemediationJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "mendabot-aaa777", Namespace: agentNamespace},
+		Spec: v1alpha1.RemediationJobSpec{
+			SourceResultRef: v1alpha1.ResultRef{Name: "svc-g", Namespace: "default"},
+			Fingerprint:     "aaa777bbb888ccc999",
+			SourceType:      "native",
+			SinkType:        "github",
+			Finding:         v1alpha1.FindingSpec{Kind: "Deployment", Name: "svc-g", Namespace: "default"},
+			GitOpsRepo:      "org/repo",
+			AgentImage:      "img",
+			AgentSA:         "sa",
+		},
+		Status: v1alpha1.RemediationJobStatus{
+			Phase:   v1alpha1.PhaseSucceeded,
+			SinkRef: makeSinkRef("https://github.com/org/repo/pull/47"),
+		},
+	}
+	c := newTestClient(obj, rjob)
+	closer := &fakeSinkCloser{err: errors.New("network error")}
+	p := &fakeSourceProvider{name: "fake", objectType: &corev1.ConfigMap{}, finding: nil}
+	r := newAutoCloseReconciler(p, c, closer, true)
+
+	_, err := r.Reconcile(context.Background(), reqFor("svc-g", "default"))
+	if err != nil {
+		t.Fatalf("expected nil, got: %v", err)
+	}
+
+	var remaining v1alpha1.RemediationJob
+	if getErr := c.Get(context.Background(), types.NamespacedName{Name: rjob.Name, Namespace: agentNamespace}, &remaining); getErr != nil {
+		t.Errorf("rjob should still exist after Close error, got: %v", getErr)
+	}
+}
+
+// TestAutoClose_PathB_NilSinkCloser_NoPanic verifies that a nil SinkCloser
+// does not cause a panic (PRAutoClose=false guards the nil).
+func TestAutoClose_PathB_NilSinkCloser_NoPanic(t *testing.T) {
+	t.Parallel()
+	obj := makeWatchedObject("svc-h", "default")
+	rjob := &v1alpha1.RemediationJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "mendabot-aaa888", Namespace: agentNamespace},
+		Spec: v1alpha1.RemediationJobSpec{
+			SourceResultRef: v1alpha1.ResultRef{Name: "svc-h", Namespace: "default"},
+			Fingerprint:     "aaa888bbb999ccc000",
+			SourceType:      "native",
+			SinkType:        "github",
+			Finding:         v1alpha1.FindingSpec{Kind: "Deployment"},
+			GitOpsRepo:      "org/repo",
+			AgentImage:      "img",
+			AgentSA:         "sa",
+		},
+		Status: v1alpha1.RemediationJobStatus{
+			Phase:   v1alpha1.PhaseSucceeded,
+			SinkRef: makeSinkRef("https://github.com/org/repo/pull/48"),
+		},
+	}
+	c := newTestClient(obj, rjob)
+	p := &fakeSourceProvider{name: "fake", objectType: &corev1.ConfigMap{}, finding: nil}
+	r := newAutoCloseReconciler(p, c, nil, false) // nil SinkCloser, PRAutoClose=false
+
+	_, err := r.Reconcile(context.Background(), reqFor("svc-h", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestAutoClose_PathB_IsNotFound_SucceededJob verifies Path B runs in the
+// IsNotFound (source deleted) path, not just the finding==nil path.
+func TestAutoClose_PathB_IsNotFound_SucceededJob(t *testing.T) {
+	t.Parallel()
+	rjob := &v1alpha1.RemediationJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "mendabot-bbb111", Namespace: agentNamespace},
+		Spec: v1alpha1.RemediationJobSpec{
+			SourceResultRef: v1alpha1.ResultRef{Name: "svc-i", Namespace: "default"},
+			Fingerprint:     "bbb111ccc222ddd333",
+			SourceType:      "native",
+			SinkType:        "github",
+			Finding:         v1alpha1.FindingSpec{Kind: "Deployment", Name: "svc-i", Namespace: "default"},
+			GitOpsRepo:      "org/repo",
+			AgentImage:      "img",
+			AgentSA:         "sa",
+		},
+		Status: v1alpha1.RemediationJobStatus{
+			Phase:   v1alpha1.PhaseSucceeded,
+			SinkRef: makeSinkRef("https://github.com/org/repo/pull/49"),
+		},
+	}
+	// Source object NOT in client → IsNotFound
+	c := newTestClient(rjob)
+	closer := &fakeSinkCloser{}
+	p := &fakeSourceProvider{name: "fake", objectType: &corev1.ConfigMap{}}
+	r := newAutoCloseReconciler(p, c, closer, true)
+
+	_, err := r.Reconcile(context.Background(), reqFor("svc-i", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(closer.calls) != 1 {
+		t.Fatalf("expected 1 Close call for Succeeded rjob in IsNotFound path, got %d", len(closer.calls))
+	}
+
+	// rjob must NOT be deleted.
+	var remaining v1alpha1.RemediationJob
+	if err := c.Get(context.Background(), types.NamespacedName{Name: rjob.Name, Namespace: agentNamespace}, &remaining); err != nil {
+		t.Errorf("rjob should still exist after Path B auto-close, got: %v", err)
+	}
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -3234,6 +3234,123 @@ func TestAutoClose_PathA_InFlightJobWithSinkRef(t *testing.T) {
 	}
 }
 
+// TestAutoClose_PathA_DispatchedJobWithSinkRef verifies that a Dispatched rjob
+// (non-terminal) with a SinkRef triggers SinkCloser before cancellation.
+func TestAutoClose_PathA_DispatchedJobWithSinkRef(t *testing.T) {
+	t.Parallel()
+	rjob := &v1alpha1.RemediationJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "mendabot-dsp001", Namespace: agentNamespace},
+		Spec: v1alpha1.RemediationJobSpec{
+			SourceResultRef: v1alpha1.ResultRef{Name: "svc-dsp", Namespace: "default"},
+			Fingerprint:     "dsp001bbb222ccc333",
+			SourceType:      "native",
+			SinkType:        "github",
+			Finding:         v1alpha1.FindingSpec{Kind: "Deployment", Name: "svc-dsp", Namespace: "default"},
+			GitOpsRepo:      "org/repo",
+			AgentImage:      "img",
+			AgentSA:         "sa",
+		},
+		Status: v1alpha1.RemediationJobStatus{
+			Phase:   v1alpha1.PhaseDispatched,
+			SinkRef: makeSinkRef("https://github.com/org/repo/pull/101"),
+		},
+	}
+	c := newTestClient(rjob)
+
+	closer := &fakeSinkCloser{}
+	p := &fakeSourceProvider{name: "fake", objectType: &corev1.ConfigMap{}}
+	r := newAutoCloseReconciler(p, c, closer, true)
+
+	_, err := r.Reconcile(context.Background(), reqFor("svc-dsp", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(closer.calls) != 1 {
+		t.Fatalf("expected 1 SinkCloser.Close call for Dispatched phase, got %d", len(closer.calls))
+	}
+	if closer.calls[0].sinkURL != "https://github.com/org/repo/pull/101" {
+		t.Errorf("unexpected sinkURL: %q", closer.calls[0].sinkURL)
+	}
+}
+
+// TestAutoClose_PathA_RunningJobWithSinkRef verifies that a Running rjob
+// (non-terminal) with a SinkRef triggers SinkCloser before cancellation.
+func TestAutoClose_PathA_RunningJobWithSinkRef(t *testing.T) {
+	t.Parallel()
+	rjob := &v1alpha1.RemediationJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "mendabot-run001", Namespace: agentNamespace},
+		Spec: v1alpha1.RemediationJobSpec{
+			SourceResultRef: v1alpha1.ResultRef{Name: "svc-run", Namespace: "default"},
+			Fingerprint:     "run001bbb222ccc333",
+			SourceType:      "native",
+			SinkType:        "github",
+			Finding:         v1alpha1.FindingSpec{Kind: "Deployment", Name: "svc-run", Namespace: "default"},
+			GitOpsRepo:      "org/repo",
+			AgentImage:      "img",
+			AgentSA:         "sa",
+		},
+		Status: v1alpha1.RemediationJobStatus{
+			Phase:   v1alpha1.PhaseRunning,
+			SinkRef: makeSinkRef("https://github.com/org/repo/pull/102"),
+		},
+	}
+	c := newTestClient(rjob)
+
+	closer := &fakeSinkCloser{}
+	p := &fakeSourceProvider{name: "fake", objectType: &corev1.ConfigMap{}}
+	r := newAutoCloseReconciler(p, c, closer, true)
+
+	_, err := r.Reconcile(context.Background(), reqFor("svc-run", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(closer.calls) != 1 {
+		t.Fatalf("expected 1 SinkCloser.Close call for Running phase, got %d", len(closer.calls))
+	}
+	if closer.calls[0].sinkURL != "https://github.com/org/repo/pull/102" {
+		t.Errorf("unexpected sinkURL: %q", closer.calls[0].sinkURL)
+	}
+}
+
+// TestAutoClose_PathA_SuppressedJobWithSinkRef verifies that a Suppressed rjob
+// (non-terminal) with a SinkRef triggers SinkCloser before cancellation.
+func TestAutoClose_PathA_SuppressedJobWithSinkRef(t *testing.T) {
+	t.Parallel()
+	rjob := &v1alpha1.RemediationJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "mendabot-sup001", Namespace: agentNamespace},
+		Spec: v1alpha1.RemediationJobSpec{
+			SourceResultRef: v1alpha1.ResultRef{Name: "svc-sup", Namespace: "default"},
+			Fingerprint:     "sup001bbb222ccc333",
+			SourceType:      "native",
+			SinkType:        "github",
+			Finding:         v1alpha1.FindingSpec{Kind: "Deployment", Name: "svc-sup", Namespace: "default"},
+			GitOpsRepo:      "org/repo",
+			AgentImage:      "img",
+			AgentSA:         "sa",
+		},
+		Status: v1alpha1.RemediationJobStatus{
+			Phase:   v1alpha1.PhaseSuppressed,
+			SinkRef: makeSinkRef("https://github.com/org/repo/pull/103"),
+		},
+	}
+	c := newTestClient(rjob)
+
+	closer := &fakeSinkCloser{}
+	p := &fakeSourceProvider{name: "fake", objectType: &corev1.ConfigMap{}}
+	r := newAutoCloseReconciler(p, c, closer, true)
+
+	_, err := r.Reconcile(context.Background(), reqFor("svc-sup", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(closer.calls) != 1 {
+		t.Fatalf("expected 1 SinkCloser.Close call for Suppressed phase, got %d", len(closer.calls))
+	}
+	if closer.calls[0].sinkURL != "https://github.com/org/repo/pull/103" {
+		t.Errorf("unexpected sinkURL: %q", closer.calls[0].sinkURL)
+	}
+}
+
 // TestAutoClose_PathA_InFlightJobWithoutSinkRef verifies that a Pending rjob
 // with empty SinkRef does NOT trigger SinkCloser.
 func TestAutoClose_PathA_InFlightJobWithoutSinkRef(t *testing.T) {

--- a/internal/sink/github/closer.go
+++ b/internal/sink/github/closer.go
@@ -1,0 +1,126 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	v1alpha1 "github.com/lenaxia/k8s-mendabot/api/v1alpha1"
+	"github.com/lenaxia/k8s-mendabot/internal/domain"
+	igithub "github.com/lenaxia/k8s-mendabot/internal/github"
+)
+
+// Compile-time interface check.
+var _ domain.SinkCloser = (*GitHubSinkCloser)(nil)
+
+// GitHubSinkCloser closes GitHub PRs and issues via the REST API.
+// No gh CLI subprocess is used — the watcher container does not contain it.
+type GitHubSinkCloser struct {
+	TokenProvider igithub.TokenProvider
+	// BaseURL allows overriding the GitHub API endpoint in tests.
+	// Defaults to "https://api.github.com" when empty.
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+// Close posts a closure comment and closes the PR or issue referenced by
+// rjob.Status.SinkRef.
+//
+// Returns nil if SinkRef.URL is empty (no sink to close).
+// Returns nil if GitHub responds with 422 on the close step (already closed — idempotent).
+// Returns an error for any other non-2xx response, or if SinkRef fields are invalid.
+//
+// Comment failure is non-fatal: the comment error is discarded and Close proceeds to
+// close the item. The primary goal is closing the sink; a missing comment is acceptable.
+func (c *GitHubSinkCloser) Close(ctx context.Context, rjob *v1alpha1.RemediationJob, reason string) error {
+	ref := rjob.Status.SinkRef
+	if ref.URL == "" {
+		return nil
+	}
+	if ref.Number <= 0 {
+		return fmt.Errorf("SinkRef.Number must be > 0, got %d (sinkRef.url=%s)", ref.Number, ref.URL)
+	}
+	if ref.Repo == "" {
+		return fmt.Errorf("SinkRef.Repo must not be empty (sinkRef.url=%s)", ref.URL)
+	}
+
+	token, err := c.TokenProvider.Token(ctx)
+	if err != nil {
+		return fmt.Errorf("getting GitHub token: %w", err)
+	}
+
+	base := c.BaseURL
+	if base == "" {
+		base = "https://api.github.com"
+	}
+	hc := c.HTTPClient
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+
+	// Step 1: post the closure comment. Failure is non-fatal — fall through.
+	_ = c.postComment(ctx, hc, base, token, ref.Repo, ref.Number, reason)
+
+	// Step 2: close the PR or issue.
+	return c.closeItem(ctx, hc, base, token, ref.Repo, ref.Number, ref.Type)
+}
+
+func (c *GitHubSinkCloser) postComment(
+	ctx context.Context, hc *http.Client, base, token, repo string, number int, body string,
+) error {
+	url := fmt.Sprintf("%s/repos/%s/issues/%d/comments", base, repo, number)
+	payload, _ := json.Marshal(map[string]string{"body": body})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("building comment request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("posting comment: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusCreated {
+		return nil
+	}
+	return fmt.Errorf("posting comment: unexpected status %d", resp.StatusCode)
+}
+
+func (c *GitHubSinkCloser) closeItem(
+	ctx context.Context, hc *http.Client, base, token, repo string, number int, sinkType string,
+) error {
+	var apiPath string
+	switch sinkType {
+	case "pr":
+		apiPath = fmt.Sprintf("%s/repos/%s/pulls/%d", base, repo, number)
+	default: // "issue" or anything else
+		apiPath = fmt.Sprintf("%s/repos/%s/issues/%d", base, repo, number)
+	}
+
+	payload, _ := json.Marshal(map[string]string{"state": "closed"})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, apiPath, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("building close request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("closing %s: %w", sinkType, err)
+	}
+	defer resp.Body.Close()
+
+	// 200 OK is success. 422 means already closed — treat as success (idempotent).
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusUnprocessableEntity {
+		return nil
+	}
+	return fmt.Errorf("closing %s: unexpected status %d", sinkType, resp.StatusCode)
+}

--- a/internal/sink/github/closer_test.go
+++ b/internal/sink/github/closer_test.go
@@ -1,0 +1,325 @@
+package github_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	v1alpha1 "github.com/lenaxia/k8s-mendabot/api/v1alpha1"
+	"github.com/lenaxia/k8s-mendabot/internal/domain"
+	sinkhub "github.com/lenaxia/k8s-mendabot/internal/sink/github"
+)
+
+// Compile-time interface check.
+var _ domain.SinkCloser = (*sinkhub.GitHubSinkCloser)(nil)
+
+// staticTokenProvider is a test double for TokenProvider.
+type staticTokenProvider struct {
+	token string
+	err   error
+}
+
+func (s *staticTokenProvider) Token(_ context.Context) (string, error) {
+	return s.token, s.err
+}
+
+// routeHandler stores per-path handlers for the mock server.
+type routeHandler struct {
+	handlers map[string]http.HandlerFunc
+}
+
+func (r *routeHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	key := req.Method + " " + req.URL.Path
+	if h, ok := r.handlers[key]; ok {
+		h(w, req)
+		return
+	}
+	http.Error(w, fmt.Sprintf("unexpected request: %s %s", req.Method, req.URL.Path), http.StatusInternalServerError)
+}
+
+func newCloser(t *testing.T, token string, mux *routeHandler) (*sinkhub.GitHubSinkCloser, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	closer := &sinkhub.GitHubSinkCloser{
+		TokenProvider: &staticTokenProvider{token: token},
+		BaseURL:       srv.URL,
+		HTTPClient:    srv.Client(),
+	}
+	return closer, srv
+}
+
+func TestGitHubSinkCloser_HappyPath_PR(t *testing.T) {
+	t.Parallel()
+	mux := &routeHandler{handlers: map[string]http.HandlerFunc{
+		"POST /repos/org/repo/issues/42/comments": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+		},
+		"PATCH /repos/org/repo/pulls/42": func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]string
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if body["state"] != "closed" {
+				http.Error(w, "bad state", http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		},
+	}}
+	closer, _ := newCloser(t, "tok", mux)
+	rjob := &v1alpha1.RemediationJob{
+		Status: v1alpha1.RemediationJobStatus{
+			SinkRef: v1alpha1.SinkRef{
+				Type:   "pr",
+				URL:    "https://github.com/org/repo/pull/42",
+				Number: 42,
+				Repo:   "org/repo",
+			},
+		},
+	}
+	if err := closer.Close(context.Background(), rjob, "resolved"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGitHubSinkCloser_HappyPath_Issue(t *testing.T) {
+	t.Parallel()
+	mux := &routeHandler{handlers: map[string]http.HandlerFunc{
+		"POST /repos/org/repo/issues/99/comments": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+		},
+		"PATCH /repos/org/repo/issues/99": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		},
+	}}
+	closer, _ := newCloser(t, "tok", mux)
+	rjob := &v1alpha1.RemediationJob{
+		Status: v1alpha1.RemediationJobStatus{
+			SinkRef: v1alpha1.SinkRef{
+				Type:   "issue",
+				URL:    "https://github.com/org/repo/issues/99",
+				Number: 99,
+				Repo:   "org/repo",
+			},
+		},
+	}
+	if err := closer.Close(context.Background(), rjob, "resolved"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGitHubSinkCloser_Idempotent_422OnClose(t *testing.T) {
+	t.Parallel()
+	mux := &routeHandler{handlers: map[string]http.HandlerFunc{
+		"POST /repos/org/repo/issues/42/comments": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+		},
+		"PATCH /repos/org/repo/pulls/42": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity) // already closed
+		},
+	}}
+	closer, _ := newCloser(t, "tok", mux)
+	rjob := &v1alpha1.RemediationJob{
+		Status: v1alpha1.RemediationJobStatus{
+			SinkRef: v1alpha1.SinkRef{Type: "pr", URL: "u", Number: 42, Repo: "org/repo"},
+		},
+	}
+	if err := closer.Close(context.Background(), rjob, "reason"); err != nil {
+		t.Fatalf("expected nil for 422 on close (idempotent), got: %v", err)
+	}
+}
+
+func TestGitHubSinkCloser_EmptySinkRef_NoHTTPCalls(t *testing.T) {
+	t.Parallel()
+	called := false
+	mux := &routeHandler{handlers: map[string]http.HandlerFunc{
+		"POST /any": func(w http.ResponseWriter, r *http.Request) { called = true },
+	}}
+	closer, _ := newCloser(t, "tok", mux)
+	rjob := &v1alpha1.RemediationJob{} // zero SinkRef
+	if err := closer.Close(context.Background(), rjob, "reason"); err != nil {
+		t.Fatalf("expected nil for empty SinkRef, got: %v", err)
+	}
+	if called {
+		t.Error("HTTP call made when SinkRef.URL is empty")
+	}
+}
+
+func TestGitHubSinkCloser_TokenProviderError(t *testing.T) {
+	t.Parallel()
+	httpCalled := false
+	mux := &routeHandler{handlers: map[string]http.HandlerFunc{
+		"POST /any": func(w http.ResponseWriter, r *http.Request) { httpCalled = true },
+	}}
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	closer := &sinkhub.GitHubSinkCloser{
+		TokenProvider: &staticTokenProvider{err: fmt.Errorf("auth failed")},
+		BaseURL:       srv.URL,
+		HTTPClient:    srv.Client(),
+	}
+	rjob := &v1alpha1.RemediationJob{
+		Status: v1alpha1.RemediationJobStatus{
+			SinkRef: v1alpha1.SinkRef{Type: "pr", URL: "u", Number: 42, Repo: "org/repo"},
+		},
+	}
+	err := closer.Close(context.Background(), rjob, "reason")
+	if err == nil {
+		t.Fatal("expected error when token provider fails")
+	}
+	if httpCalled {
+		t.Error("HTTP call made despite token provider error")
+	}
+}
+
+func TestGitHubSinkCloser_CommentFailure_StillCloses(t *testing.T) {
+	t.Parallel()
+	closeCalled := false
+	mux := &routeHandler{handlers: map[string]http.HandlerFunc{
+		"POST /repos/org/repo/issues/42/comments": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity) // comment fails
+		},
+		"PATCH /repos/org/repo/pulls/42": func(w http.ResponseWriter, r *http.Request) {
+			closeCalled = true
+			w.WriteHeader(http.StatusOK)
+		},
+	}}
+	closer, _ := newCloser(t, "tok", mux)
+	rjob := &v1alpha1.RemediationJob{
+		Status: v1alpha1.RemediationJobStatus{
+			SinkRef: v1alpha1.SinkRef{Type: "pr", URL: "u", Number: 42, Repo: "org/repo"},
+		},
+	}
+	if err := closer.Close(context.Background(), rjob, "reason"); err != nil {
+		t.Fatalf("Close should succeed even if comment fails, got: %v", err)
+	}
+	if !closeCalled {
+		t.Error("PATCH (close) was not called despite comment failure")
+	}
+}
+
+func TestGitHubSinkCloser_Comment500_StillCloses(t *testing.T) {
+	t.Parallel()
+	closeCalled := false
+	mux := &routeHandler{handlers: map[string]http.HandlerFunc{
+		"POST /repos/org/repo/issues/42/comments": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		},
+		"PATCH /repos/org/repo/pulls/42": func(w http.ResponseWriter, r *http.Request) {
+			closeCalled = true
+			w.WriteHeader(http.StatusOK)
+		},
+	}}
+	closer, _ := newCloser(t, "tok", mux)
+	rjob := &v1alpha1.RemediationJob{
+		Status: v1alpha1.RemediationJobStatus{
+			SinkRef: v1alpha1.SinkRef{Type: "pr", URL: "u", Number: 42, Repo: "org/repo"},
+		},
+	}
+	if err := closer.Close(context.Background(), rjob, "reason"); err != nil {
+		t.Fatalf("expected nil despite comment 500, got: %v", err)
+	}
+	if !closeCalled {
+		t.Error("PATCH not called")
+	}
+}
+
+func TestGitHubSinkCloser_InvalidNumber_Zero(t *testing.T) {
+	t.Parallel()
+	httpCalled := false
+	mux := &routeHandler{handlers: map[string]http.HandlerFunc{
+		"ANY": func(w http.ResponseWriter, r *http.Request) { httpCalled = true },
+	}}
+	closer, _ := newCloser(t, "tok", mux)
+	rjob := &v1alpha1.RemediationJob{
+		Status: v1alpha1.RemediationJobStatus{
+			SinkRef: v1alpha1.SinkRef{Type: "pr", URL: "https://github.com/org/repo/pull/0", Number: 0, Repo: "org/repo"},
+		},
+	}
+	err := closer.Close(context.Background(), rjob, "reason")
+	if err == nil {
+		t.Fatal("expected error for Number=0")
+	}
+	if httpCalled {
+		t.Error("HTTP call made despite invalid Number")
+	}
+}
+
+func TestGitHubSinkCloser_InvalidNumber_Negative(t *testing.T) {
+	t.Parallel()
+	mux := &routeHandler{handlers: map[string]http.HandlerFunc{}}
+	closer, _ := newCloser(t, "tok", mux)
+	rjob := &v1alpha1.RemediationJob{
+		Status: v1alpha1.RemediationJobStatus{
+			SinkRef: v1alpha1.SinkRef{Type: "pr", URL: "u", Number: -1, Repo: "org/repo"},
+		},
+	}
+	if err := closer.Close(context.Background(), rjob, "reason"); err == nil {
+		t.Fatal("expected error for Number=-1")
+	}
+}
+
+func TestGitHubSinkCloser_InvalidRepo_Empty(t *testing.T) {
+	t.Parallel()
+	mux := &routeHandler{handlers: map[string]http.HandlerFunc{}}
+	closer, _ := newCloser(t, "tok", mux)
+	rjob := &v1alpha1.RemediationJob{
+		Status: v1alpha1.RemediationJobStatus{
+			SinkRef: v1alpha1.SinkRef{Type: "pr", URL: "u", Number: 42, Repo: ""},
+		},
+	}
+	if err := closer.Close(context.Background(), rjob, "reason"); err == nil {
+		t.Fatal("expected error for empty Repo")
+	}
+}
+
+func TestGitHubSinkCloser_UnexpectedStatusOnClose(t *testing.T) {
+	t.Parallel()
+	mux := &routeHandler{handlers: map[string]http.HandlerFunc{
+		"POST /repos/org/repo/issues/42/comments": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+		},
+		"PATCH /repos/org/repo/pulls/42": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		},
+	}}
+	closer, _ := newCloser(t, "tok", mux)
+	rjob := &v1alpha1.RemediationJob{
+		Status: v1alpha1.RemediationJobStatus{
+			SinkRef: v1alpha1.SinkRef{Type: "pr", URL: "u", Number: 42, Repo: "org/repo"},
+		},
+	}
+	err := closer.Close(context.Background(), rjob, "reason")
+	if err == nil {
+		t.Fatal("expected error for 500 on close")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("expected '500' in error message, got: %v", err)
+	}
+}
+
+func TestGitHubSinkCloser_CancelledContext(t *testing.T) {
+	t.Parallel()
+	mux := &routeHandler{handlers: map[string]http.HandlerFunc{
+		"POST /repos/org/repo/issues/42/comments": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+		},
+	}}
+	closer, _ := newCloser(t, "tok", mux)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancelled before call
+
+	rjob := &v1alpha1.RemediationJob{
+		Status: v1alpha1.RemediationJobStatus{
+			SinkRef: v1alpha1.SinkRef{Type: "pr", URL: "u", Number: 42, Repo: "org/repo"},
+		},
+	}
+	err := closer.Close(ctx, rjob, "reason")
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}

--- a/testdata/crds/remediationjob_crd.yaml
+++ b/testdata/crds/remediationjob_crd.yaml
@@ -309,6 +309,24 @@ spec:
                   whether to re-dispatch or tombstone.
                 format: int32
                 type: integer
+              sinkRef:
+                description: |-
+                  SinkRef identifies the GitHub PR or issue opened by the agent.
+                  Empty until the agent writes it after opening the sink.
+                type: object
+                properties:
+                  type:
+                    description: Type is "pr" or "issue".
+                    type: string
+                  url:
+                    description: URL is the full HTML URL (e.g. https://github.com/org/repo/pull/42).
+                    type: string
+                  number:
+                    description: Number is the PR or issue number. Required for GitHub REST API calls.
+                    type: integer
+                  repo:
+                    description: Repo is "owner/repo" format (e.g. "lenaxia/talos-ops-prod").
+                    type: string
             type: object
         required:
         - spec

--- a/testdata/crds/remediationjob_crd.yaml
+++ b/testdata/crds/remediationjob_crd.yaml
@@ -313,20 +313,30 @@ spec:
                 description: |-
                   SinkRef identifies the GitHub PR or issue opened by the agent.
                   Empty until the agent writes it after opening the sink.
-                type: object
                 properties:
+                  number:
+                    description: Number is the PR or issue number. Required for GitHub
+                      REST API calls.
+                    type: integer
+                  repo:
+                    description: |-
+                      Repo is "owner/repo" format (e.g. "lenaxia/talos-ops-prod").
+                      Required for GitHub REST API calls.
+                    type: string
                   type:
                     description: Type is "pr" or "issue".
                     type: string
                   url:
-                    description: URL is the full HTML URL (e.g. https://github.com/org/repo/pull/42).
+                    description: |-
+                      URL is the full HTML URL (e.g. https://github.com/org/repo/pull/42).
+                      Used in log messages and closure comments.
                     type: string
-                  number:
-                    description: Number is the PR or issue number. Required for GitHub REST API calls.
-                    type: integer
-                  repo:
-                    description: Repo is "owner/repo" format (e.g. "lenaxia/talos-ops-prod").
-                    type: string
+                required:
+                - number
+                - repo
+                - type
+                - url
+                type: object
             type: object
         required:
         - spec


### PR DESCRIPTION
## Summary

Implements Epic 26 — when a Kubernetes finding clears (deployment recovers, PVC is
provisioned, node returns Ready), the watcher now automatically closes the GitHub PR
that the agent opened.

**Two trigger paths:**
- **Path A** — in-flight jobs (Pending/Dispatched/Running): close sink then cancel rjob
- **Path B** — already-succeeded jobs: close stale PR without deleting the dedup tombstone

## Stories

| Story | Description |
|-------|-------------|
| STORY_00 | `SinkRef` domain type (`type`, `url`, `number`, `repo`) + `SinkCloser` interface |
| STORY_01 | GitHub App token provider in watcher — RS256 JWT exchange, 55-min in-memory cache |
| STORY_02 | `GitHubSinkCloser` — REST API (no `gh` CLI), HTTP 422 = idempotent success |
| STORY_03 | Wire `SinkCloser` into `SourceProviderReconciler` — Path A + Path B |
| STORY_04 | Helm chart Secret mount + `PR_AUTO_CLOSE` env var; `NoopSinkCloser` when disabled |
| STORY_05 | Agent prompt STEP 9 — writes `SinkRef` back to `RemediationJob` status after PR open |

## Key Design Decisions

- **REST API not `gh` CLI** — `gh` is absent from the watcher container
- **HTTP 422 = success** — GitHub returns 422 on already-closed PR; idempotency required
- **`postComment` failure is non-fatal** — PR closure never gated on comment success
- **`PhaseSucceeded` rjobs NOT deleted** — they serve as dedup tombstones until TTL
- **Secret mount is required** — pod fails fast at startup if GitHub App Secret is missing
- **Old rjobs silently skipped** — `SinkRef.URL == ""` check; no retroactive closure

## Testing

All code covered by unit tests using mock HTTP servers. Full suite:
```
go test -timeout 30s -race ./...   # all pass
go build ./...                     # clean
```

## Backwards Compatibility

Pre-epic26 `RemediationJob` objects with only `status.prRef` and no `status.sinkRef`
are silently skipped by the auto-close logic. Migration is natural via TTL expiry.

## Verification (post-deploy)

```bash
# After agent completes: confirm SinkRef populated
kubectl get rjob -n mendabot mendabot-<fp12> -o jsonpath='{.status.sinkRef}'

# After finding resolves: PR should be auto-closed with closure comment
```