### PR TITLE
fix: suppress Pod findings even when Deployment-level RJob is Succeeded

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -441,14 +441,15 @@ func (r *SourceProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
-	// Parent-hierarchy suppression: if an active RemediationJob already exists for
-	// the same namespace+parentObject with a higher-hierarchy kind (e.g. Deployment
-	// while this finding is a Pod), suppress this finding. This prevents duplicate
-	// investigations when the native provider emits both a Deployment finding and a
-	// Pod finding for the same parent — the Deployment-level investigation covers both.
+	// Parent-hierarchy suppression: if a RemediationJob already exists for the same
+	// namespace+parentObject with a higher-hierarchy kind (e.g. Deployment while this
+	// finding is a Pod), suppress this finding — regardless of that peer's phase.
 	//
-	// "Active" means any phase except Succeeded (which is terminal and no longer
-	// represents an ongoing investigation).
+	// Rationale: a Deployment-level investigation covers all Pods owned by that
+	// Deployment. Allowing Pod-level jobs to fire after the Deployment job Succeeded
+	// (but the problem persisted) leads to unbounded Pod-level RJobs for every new
+	// rollout attempt. Instead, the Deployment fingerprint's own dedup TTL governs
+	// when a fresh Deployment-level investigation is allowed.
 	if finding.ParentObject != "" {
 		var allRjobs v1alpha1.RemediationJobList
 		if err := r.List(ctx, &allRjobs,
@@ -466,9 +467,6 @@ func (r *SourceProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			if peer.Spec.Finding.ParentObject != finding.ParentObject {
 				continue
 			}
-			if peer.Status.Phase == v1alpha1.PhaseSucceeded {
-				continue
-			}
 			peerRank := domain.KindHierarchyRank(peer.Spec.Finding.Kind)
 			if peerRank > thisRank {
 				if r.Log != nil {
@@ -480,6 +478,7 @@ func (r *SourceProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 						zap.String("kind", finding.Kind),
 						zap.String("parentObject", finding.ParentObject),
 						zap.String("supersededBy", peer.Name),
+						zap.String("supersededByPhase", string(peer.Status.Phase)),
 						zap.String("supersededByKind", peer.Spec.Finding.Kind),
 					)
 				}


### PR DESCRIPTION
## Problem

After #19 landed, the parent-hierarchy suppression still skipped peers in `PhaseSucceeded`. This meant:

1. Deployment-level RJob for `vllm-classifier` ran and reached `Succeeded` (PR opened, problem not fixed)
2. Pods kept restarting — each new Pod (new name from rollout retry) got a fresh fingerprint
3. The suppression skipped the Succeeded Deployment peer → 3 new Pod-level RJobs spawned

## Fix

Remove the `PhaseSucceeded` skip from the parent-hierarchy suppression loop. Now **any** higher-rank RJob for the same `namespace+parentObject` suppresses a lower-rank finding, regardless of phase.

The Deployment fingerprint's own dedup TTL (`StabilisationWindow * 2`, default ~4 min) governs when a fresh Deployment-level re-investigation is allowed. Pod-level jobs for a Deployment's Pods are always redundant.

Also adds `supersededByPhase` to the `finding.suppressed.parent_hierarchy` audit log event.

## Testing
- `go build ./...` — clean
- `go test -race ./...` — all 18 packages pass (run 3×)