### PR TITLE
feat: PR-merge-aware dedup tombstones with short/long TTL split

### DIFF
--- a/api/v1alpha1/remediationjob_types.go
+++ b/api/v1alpha1/remediationjob_types.go
@@ -256,6 +256,19 @@ type RemediationJobStatus struct {
 	// Empty until the agent writes it after opening the sink.
 	// +optional
 	SinkRef SinkRef `json:"sinkRef,omitempty"`
+
+	// PRMerged is true once the provider has confirmed that the GitHub PR
+	// referenced by SinkRef was merged.  When true, the long TTL
+	// (REMEDIATION_JOB_TTL_SECONDS) is used relative to PRMergedAt.
+	// When false (or absent), the short TTL (REMEDIATION_JOB_SHORT_TTL_SECONDS)
+	// is used relative to CompletedAt.
+	// +optional
+	PRMerged bool `json:"prMerged,omitempty"`
+
+	// PRMergedAt is the time the provider confirmed the PR was merged.
+	// Only set when PRMerged is true.
+	// +optional
+	PRMergedAt *metav1.Time `json:"prMergedAt,omitempty"`
 }
 
 // RemediationJob represents one investigation and remediation attempt for a
@@ -308,6 +321,11 @@ func (in *RemediationJob) DeepCopyInto(out *RemediationJob) {
 	out.Status.CorrelationGroupID = in.Status.CorrelationGroupID
 	// SinkRef contains only value types (string, int); shallow copy is correct.
 	out.Status.SinkRef = in.Status.SinkRef
+	out.Status.PRMerged = in.Status.PRMerged
+	if in.Status.PRMergedAt != nil {
+		t := *in.Status.PRMergedAt
+		out.Status.PRMergedAt = &t
+	}
 }
 
 // DeepCopyObject implements runtime.Object.

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -211,6 +211,7 @@ func main() {
 	// secretKeyRef entries on the Deployment (conditional on prAutoClose) guarantee these vars are present when the pod starts.
 	// If PRAutoClose is false, use NoopSinkCloser — no credentials needed.
 	var sinkCloser domain.SinkCloser
+	var prMergeChecker domain.PRMergeChecker
 	if cfg.PRAutoClose {
 		appID, err := strconv.ParseInt(os.Getenv("GITHUB_APP_ID"), 10, 64)
 		if err != nil || appID <= 0 {
@@ -227,16 +228,17 @@ func main() {
 			logger.Fatal("GITHUB_APP_PRIVATE_KEY is missing or invalid; cannot start with PR_AUTO_CLOSE=true",
 				zap.Error(err))
 		}
-		sinkCloser = &sinkhub.GitHubSinkCloser{
-			TokenProvider: &igithub.GitHubAppTokenProvider{
-				AppID:          appID,
-				InstallationID: installID,
-				PrivateKey:     privKey,
-			},
+		tp := &igithub.GitHubAppTokenProvider{
+			AppID:          appID,
+			InstallationID: installID,
+			PrivateKey:     privKey,
 		}
+		sinkCloser = &sinkhub.GitHubSinkCloser{TokenProvider: tp}
+		prMergeChecker = &sinkhub.GitHubPRMergeChecker{TokenProvider: tp}
 		logger.Info("auto-close sink enabled", zap.Bool("prAutoClose", true))
 	} else {
 		sinkCloser = domain.NoopSinkCloser{}
+		prMergeChecker = domain.NoopPRMergeChecker{}
 		logger.Info("auto-close sink disabled (PR_AUTO_CLOSE=false)")
 	}
 
@@ -251,6 +253,7 @@ func main() {
 			ReadinessChecker: combinedChecker,
 			CircuitBreaker:   cb,
 			SinkCloser:       sinkCloser,
+			PRMergeChecker:   prMergeChecker,
 		}).SetupWithManager(mgr); err != nil {
 			logger.Fatal("provider setup failed", zap.Error(err))
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,12 @@ type Config struct {
 	// PRAutoClose controls whether open sinks are auto-closed when a finding resolves.
 	// Default: true. Set PR_AUTO_CLOSE=false to disable.
 	PRAutoClose bool // PR_AUTO_CLOSE — default true
+
+	// RemediationJobShortTTLSeconds is the TTL used for Succeeded RemediationJobs
+	// whose associated PR was not merged (or no PR was opened).  Once the short TTL
+	// expires the tombstone is deleted and a fresh investigation is allowed.
+	// Default: 86400 (24 hours).  Must be < RemediationJobTTLSeconds.
+	RemediationJobShortTTLSeconds int // REMEDIATION_JOB_SHORT_TTL_SECONDS — default 86400
 }
 
 // FromEnv reads configuration from environment variables and returns a Config.
@@ -362,6 +368,25 @@ func FromEnv() (Config, error) {
 		cfg.PRAutoClose = false
 	default:
 		return Config{}, fmt.Errorf("PR_AUTO_CLOSE must be 'true', 'false', '1', or '0', got %q", prAutoCloseStr)
+	}
+
+	// REMEDIATION_JOB_SHORT_TTL_SECONDS — default 86400 (24h).
+	// Must be > 0 and < REMEDIATION_JOB_TTL_SECONDS.
+	shortTTLStr := os.Getenv("REMEDIATION_JOB_SHORT_TTL_SECONDS")
+	if shortTTLStr == "" {
+		cfg.RemediationJobShortTTLSeconds = 86400
+	} else {
+		n, err := strconv.Atoi(shortTTLStr)
+		if err != nil {
+			return Config{}, fmt.Errorf("REMEDIATION_JOB_SHORT_TTL_SECONDS must be an integer: %w", err)
+		}
+		if n <= 0 {
+			return Config{}, fmt.Errorf("REMEDIATION_JOB_SHORT_TTL_SECONDS must be a positive integer, got %d", n)
+		}
+		if n > math.MaxInt32 {
+			return Config{}, fmt.Errorf("REMEDIATION_JOB_SHORT_TTL_SECONDS must be at most %d, got %d", math.MaxInt32, n)
+		}
+		cfg.RemediationJobShortTTLSeconds = n
 	}
 
 	return cfg, nil

--- a/internal/controller/remediationjob_controller.go
+++ b/internal/controller/remediationjob_controller.go
@@ -72,6 +72,10 @@ func (r *RemediationJobReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	ttl := time.Duration(r.Cfg.RemediationJobTTLSeconds) * time.Second
+	shortTTL := time.Duration(r.Cfg.RemediationJobShortTTLSeconds) * time.Second
+	if shortTTL == 0 {
+		shortTTL = 24 * time.Hour
+	}
 
 	switch rjob.Status.Phase {
 	case v1alpha1.PhaseSucceeded:
@@ -89,7 +93,19 @@ func (r *RemediationJobReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			}
 			return ctrl.Result{RequeueAfter: time.Second}, nil
 		}
-		deadline := rjob.Status.CompletedAt.Add(ttl)
+		// Choose TTL and clock-start based on PR merge state:
+		//   PRMerged=true  → long TTL from PRMergedAt (or CompletedAt if PRMergedAt unset)
+		//   PRMerged=false → short TTL from CompletedAt
+		var deadline time.Time
+		if rjob.Status.PRMerged {
+			clockStart := rjob.Status.CompletedAt.Time
+			if rjob.Status.PRMergedAt != nil {
+				clockStart = rjob.Status.PRMergedAt.Time
+			}
+			deadline = clockStart.Add(ttl)
+		} else {
+			deadline = rjob.Status.CompletedAt.Time.Add(shortTTL)
+		}
 		if time.Now().Before(deadline) {
 			return ctrl.Result{RequeueAfter: time.Until(deadline)}, nil
 		}
@@ -103,6 +119,7 @@ func (r *RemediationJobReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				zap.String("remediationJob", rjob.Name),
 				zap.String("namespace", rjob.Namespace),
 				zap.String("prRef", rjob.Status.PRRef),
+				zap.Bool("prMerged", rjob.Status.PRMerged),
 			)
 		}
 		// CompletedAt is nil — the terminal status-patch for this job failed in a

--- a/internal/domain/sink.go
+++ b/internal/domain/sink.go
@@ -20,3 +20,23 @@ type NoopSinkCloser struct{}
 func (NoopSinkCloser) Close(_ context.Context, _ *v1alpha1.RemediationJob, _ string) error {
 	return nil
 }
+
+// PRMergeChecker checks whether the GitHub PR referenced by a SinkRef has been
+// merged.  Implementations must be safe to call concurrently and must be
+// idempotent (repeated calls for the same PR return the same result once merged).
+//
+// IsMerged returns (true, nil) when the PR is confirmed merged.
+// IsMerged returns (false, nil) when the PR is open or closed but not merged.
+// IsMerged returns (false, err) on transient errors (network, auth, rate-limit).
+// IsMerged returns (false, nil) immediately when ref.URL is empty.
+type PRMergeChecker interface {
+	IsMerged(ctx context.Context, ref v1alpha1.SinkRef) (bool, error)
+}
+
+// NoopPRMergeChecker always reports not-merged.
+// Used in tests or when no GitHub credentials are configured.
+type NoopPRMergeChecker struct{}
+
+func (NoopPRMergeChecker) IsMerged(_ context.Context, _ v1alpha1.SinkRef) (bool, error) {
+	return false, nil
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -44,8 +44,12 @@ type SourceProviderReconciler struct {
 	// SinkCloser closes open GitHub sinks when a finding resolves.
 	// nil disables auto-close (equivalent to PR_AUTO_CLOSE=false).
 	SinkCloser domain.SinkCloser
-	firstSeen  *BoundedMap
-	initOnce   sync.Once
+	// PRMergeChecker checks whether a GitHub PR has been merged.
+	// Used in the dedup path to determine whether to apply the short or long TTL.
+	// nil disables merge-state checks (all Succeeded tombstones use the short TTL).
+	PRMergeChecker domain.PRMergeChecker
+	firstSeen      *BoundedMap
+	initOnce       sync.Once
 }
 
 // ReadinessCacheTTL is the recommended TTL for CachedChecker wrappers around
@@ -423,6 +427,123 @@ func (r *SourceProviderReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			if delErr := r.Delete(ctx, rjob); delErr != nil && !apierrors.IsNotFound(delErr) {
 				return ctrl.Result{}, delErr
 			}
+		case v1alpha1.PhaseSucceeded:
+			// Tombstone TTL check: decide whether to suppress or allow re-investigation.
+			//
+			// If the PR was merged (PRMerged=true): use the long TTL.  The tombstone
+			// is still alive — suppress.
+			//
+			// If no PR was opened or the PR was not yet confirmed merged: lazily check
+			// GitHub.  On merge confirmation, patch PRMerged=true on the tombstone and
+			// suppress.  If not yet merged and within the short TTL, suppress and
+			// requeue.  If the short TTL has elapsed, allow this finding through
+			// (tombstone is effectively expired; the RJob controller will delete it
+			// on its own TTL schedule, but we don't block on that).
+			if rjob.Status.PRMerged {
+				// Already confirmed merged → suppress (long TTL governs deletion).
+				if r.Log != nil {
+					r.Log.Info("finding suppressed",
+						zap.Bool("audit", true),
+						zap.String("event", "finding.suppressed.duplicate"),
+						zap.String("provider", r.Provider.ProviderName()),
+						zap.String("fingerprint", fp[:12]),
+						zap.String("remediationJob", rjob.Name),
+						zap.String("phase", string(rjob.Status.Phase)),
+					)
+				}
+				if r.EventRecorder != nil {
+					r.EventRecorder.Eventf(obj, corev1.EventTypeNormal, "DuplicateFingerprint", "Existing RemediationJob %s already covers this finding (PR merged)", rjob.Name)
+				}
+				return ctrl.Result{}, nil
+			}
+
+			// Not yet confirmed merged — check GitHub if a PR exists and checker is wired.
+			if rjob.Status.SinkRef.URL != "" && r.PRMergeChecker != nil {
+				merged, mergeErr := r.PRMergeChecker.IsMerged(ctx, rjob.Status.SinkRef)
+				if mergeErr != nil {
+					// Transient error — treat as not-yet-merged; fall through to TTL check.
+					if r.Log != nil {
+						r.Log.Warn("PR merge check failed; treating as unmerged",
+							zap.String("remediationJob", rjob.Name),
+							zap.String("sinkURL", rjob.Status.SinkRef.URL),
+							zap.Error(mergeErr),
+						)
+					}
+				} else if merged {
+					// PR is now merged — patch the tombstone and suppress.
+					now := metav1.Now()
+					rjobCopy := rjob.DeepCopyObject().(*v1alpha1.RemediationJob)
+					rjob.Status.PRMerged = true
+					rjob.Status.PRMergedAt = &now
+					if patchErr := r.Status().Patch(ctx, rjob, client.MergeFrom(rjobCopy)); patchErr != nil && !apierrors.IsNotFound(patchErr) {
+						// Non-fatal: log and suppress anyway; patch will retry next reconcile.
+						if r.Log != nil {
+							r.Log.Warn("failed to patch PRMerged on tombstone; suppressing anyway",
+								zap.String("remediationJob", rjob.Name),
+								zap.Error(patchErr),
+							)
+						}
+					}
+					if r.Log != nil {
+						r.Log.Info("finding suppressed",
+							zap.Bool("audit", true),
+							zap.String("event", "finding.suppressed.duplicate"),
+							zap.String("provider", r.Provider.ProviderName()),
+							zap.String("fingerprint", fp[:12]),
+							zap.String("remediationJob", rjob.Name),
+							zap.String("phase", string(rjob.Status.Phase)),
+							zap.Bool("prMerged", true),
+						)
+					}
+					if r.EventRecorder != nil {
+						r.EventRecorder.Eventf(obj, corev1.EventTypeNormal, "DuplicateFingerprint", "Existing RemediationJob %s already covers this finding (PR just merged)", rjob.Name)
+					}
+					return ctrl.Result{}, nil
+				}
+			}
+
+			// PR not merged (or no checker): apply short TTL relative to CompletedAt.
+			shortTTL := time.Duration(r.Cfg.RemediationJobShortTTLSeconds) * time.Second
+			if shortTTL == 0 {
+				shortTTL = 24 * time.Hour
+			}
+			if rjob.Status.CompletedAt != nil && time.Since(rjob.Status.CompletedAt.Time) < shortTTL {
+				// Still within short TTL — suppress.
+				if r.Log != nil {
+					r.Log.Info("finding suppressed",
+						zap.Bool("audit", true),
+						zap.String("event", "finding.suppressed.duplicate"),
+						zap.String("provider", r.Provider.ProviderName()),
+						zap.String("fingerprint", fp[:12]),
+						zap.String("remediationJob", rjob.Name),
+						zap.String("phase", string(rjob.Status.Phase)),
+						zap.Bool("prMerged", false),
+						zap.Duration("shortTTLRemaining", time.Until(rjob.Status.CompletedAt.Time.Add(shortTTL))),
+					)
+				}
+				if r.EventRecorder != nil {
+					r.EventRecorder.Eventf(obj, corev1.EventTypeNormal, "DuplicateFingerprint", "Existing RemediationJob %s already covers this finding (within short TTL)", rjob.Name)
+				}
+				return ctrl.Result{}, nil
+			}
+			// Short TTL elapsed and PR not merged — delete the tombstone to make
+			// room for a fresh RJob, then requeue immediately.  On the next
+			// reconcile, the fingerprint list will be empty and a new RJob will
+			// be created.
+			if r.Log != nil {
+				r.Log.Info("tombstone short TTL elapsed; deleting tombstone for re-investigation",
+					zap.Bool("audit", true),
+					zap.String("event", "finding.tombstone_expired"),
+					zap.String("provider", r.Provider.ProviderName()),
+					zap.String("fingerprint", fp[:12]),
+					zap.String("remediationJob", rjob.Name),
+					zap.Bool("prMerged", false),
+				)
+			}
+			if delErr := r.Delete(ctx, rjob); delErr != nil && !apierrors.IsNotFound(delErr) {
+				return ctrl.Result{}, fmt.Errorf("deleting expired tombstone: %w", delErr)
+			}
+			return ctrl.Result{Requeue: true}, nil
 		default:
 			if r.Log != nil {
 				r.Log.Info("finding suppressed",

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -3662,3 +3662,368 @@ func TestAutoClose_PathB_IsNotFound_SucceededJob(t *testing.T) {
 		t.Errorf("rjob should still exist after Path B auto-close, got: %v", err)
 	}
 }
+
+// --------------------------------------------------------------------------
+// PR merge-state dedup tests
+// --------------------------------------------------------------------------
+
+// fakePRMergeChecker is a controllable domain.PRMergeChecker for unit tests.
+type fakePRMergeChecker struct {
+	merged bool
+	err    error
+	calls  int
+}
+
+func (f *fakePRMergeChecker) IsMerged(_ context.Context, ref v1alpha1.SinkRef) (bool, error) {
+	if ref.URL == "" {
+		return false, nil
+	}
+	f.calls++
+	return f.merged, f.err
+}
+
+// makeSucceededTombstone builds a Succeeded RemediationJob tombstone for dedup tests.
+func makeSucceededTombstone(fp string, completedAt time.Time, sinkURL string, prMerged bool, prMergedAt *metav1.Time) *v1alpha1.RemediationJob {
+	ca := metav1.NewTime(completedAt)
+	rjob := &v1alpha1.RemediationJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mechanic-" + fp[:12],
+			Namespace: agentNamespace,
+			Labels: map[string]string{
+				"remediation.mechanic.io/fingerprint": fp[:12],
+				"app.kubernetes.io/managed-by":        "mechanic-watcher",
+			},
+		},
+		Spec: v1alpha1.RemediationJobSpec{
+			Fingerprint: fp,
+			SourceType:  "native",
+			Finding: v1alpha1.FindingSpec{
+				Kind:         "Deployment",
+				Name:         "my-app",
+				Namespace:    "default",
+				ParentObject: "Deployment/my-app",
+			},
+		},
+		Status: v1alpha1.RemediationJobStatus{
+			Phase:       v1alpha1.PhaseSucceeded,
+			CompletedAt: &ca,
+			PRMerged:    prMerged,
+			PRMergedAt:  prMergedAt,
+		},
+	}
+	if sinkURL != "" {
+		rjob.Status.SinkRef = v1alpha1.SinkRef{
+			Type:   "pr",
+			URL:    sinkURL,
+			Number: 42,
+			Repo:   "org/repo",
+		}
+	}
+	return rjob
+}
+
+// TestDedup_PRMerged_Suppressed: PRMerged=true → suppress without calling checker.
+func TestDedup_PRMerged_Suppressed(t *testing.T) {
+	t.Parallel()
+	finding := &domain.Finding{
+		Kind: "Deployment", Name: "my-app", Namespace: "default",
+		ParentObject: "Deployment/my-app",
+		Errors:       `[{"text":"CrashLoopBackOff"}]`,
+	}
+	fp, _ := domain.FindingFingerprint(finding)
+
+	pma := metav1.NewTime(time.Now().Add(-1 * time.Hour))
+	tombstone := makeSucceededTombstone(fp, time.Now().Add(-2*time.Hour), "https://github.com/org/repo/pull/42", true, &pma)
+
+	obj := makeWatchedObject("my-app", "default")
+	c := newTestClient(obj, tombstone)
+	checker := &fakePRMergeChecker{merged: false} // should not be called
+
+	r := &provider.SourceProviderReconciler{
+		Client: c, Scheme: newTestScheme(),
+		Cfg:            config.Config{AgentNamespace: agentNamespace, RemediationJobShortTTLSeconds: 86400},
+		Provider:       &fakeSourceProvider{name: "native", objectType: &corev1.ConfigMap{}, finding: finding},
+		PRMergeChecker: checker,
+	}
+
+	_, err := r.Reconcile(context.Background(), reqFor("my-app", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if checker.calls != 0 {
+		t.Errorf("expected 0 GitHub calls when PRMerged=true, got %d", checker.calls)
+	}
+	// No new RJob should be created.
+	var list v1alpha1.RemediationJobList
+	_ = c.List(context.Background(), &list, client.InNamespace(agentNamespace))
+	if len(list.Items) != 1 {
+		t.Errorf("expected 1 rjob (tombstone only), got %d", len(list.Items))
+	}
+}
+
+// TestDedup_UnmergedWithinShortTTL_Suppressed: PR exists, not merged, within 24h → suppress.
+func TestDedup_UnmergedWithinShortTTL_Suppressed(t *testing.T) {
+	t.Parallel()
+	finding := &domain.Finding{
+		Kind: "Deployment", Name: "my-app", Namespace: "default",
+		ParentObject: "Deployment/my-app",
+		Errors:       `[{"text":"CrashLoopBackOff"}]`,
+	}
+	fp, _ := domain.FindingFingerprint(finding)
+
+	// Completed 1 hour ago → within 24h short TTL.
+	tombstone := makeSucceededTombstone(fp, time.Now().Add(-1*time.Hour), "https://github.com/org/repo/pull/42", false, nil)
+
+	obj := makeWatchedObject("my-app", "default")
+	c := newTestClient(obj, tombstone)
+	checker := &fakePRMergeChecker{merged: false} // PR not yet merged
+
+	r := &provider.SourceProviderReconciler{
+		Client: c, Scheme: newTestScheme(),
+		Cfg:            config.Config{AgentNamespace: agentNamespace, RemediationJobShortTTLSeconds: 86400},
+		Provider:       &fakeSourceProvider{name: "native", objectType: &corev1.ConfigMap{}, finding: finding},
+		PRMergeChecker: checker,
+	}
+
+	_, err := r.Reconcile(context.Background(), reqFor("my-app", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if checker.calls != 1 {
+		t.Errorf("expected 1 GitHub call for unmerged PR, got %d", checker.calls)
+	}
+	// No new RJob.
+	var list v1alpha1.RemediationJobList
+	_ = c.List(context.Background(), &list, client.InNamespace(agentNamespace))
+	if len(list.Items) != 1 {
+		t.Errorf("expected 1 rjob (tombstone only), got %d", len(list.Items))
+	}
+}
+
+// TestDedup_PRJustMerged_SuppressedAndPatched: GitHub returns merged → patch PRMerged=true, suppress.
+func TestDedup_PRJustMerged_SuppressedAndPatched(t *testing.T) {
+	t.Parallel()
+	finding := &domain.Finding{
+		Kind: "Deployment", Name: "my-app", Namespace: "default",
+		ParentObject: "Deployment/my-app",
+		Errors:       `[{"text":"CrashLoopBackOff"}]`,
+	}
+	fp, _ := domain.FindingFingerprint(finding)
+
+	tombstone := makeSucceededTombstone(fp, time.Now().Add(-30*time.Minute), "https://github.com/org/repo/pull/42", false, nil)
+
+	obj := makeWatchedObject("my-app", "default")
+	c := newTestClient(obj, tombstone)
+	checker := &fakePRMergeChecker{merged: true}
+
+	r := &provider.SourceProviderReconciler{
+		Client: c, Scheme: newTestScheme(),
+		Cfg:            config.Config{AgentNamespace: agentNamespace, RemediationJobShortTTLSeconds: 86400},
+		Provider:       &fakeSourceProvider{name: "native", objectType: &corev1.ConfigMap{}, finding: finding},
+		PRMergeChecker: checker,
+	}
+
+	_, err := r.Reconcile(context.Background(), reqFor("my-app", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if checker.calls != 1 {
+		t.Errorf("expected 1 GitHub call, got %d", checker.calls)
+	}
+	// Tombstone must have PRMerged=true patched.
+	var updated v1alpha1.RemediationJob
+	_ = c.Get(context.Background(), types.NamespacedName{Name: tombstone.Name, Namespace: agentNamespace}, &updated)
+	if !updated.Status.PRMerged {
+		t.Error("expected PRMerged=true to be patched onto tombstone")
+	}
+	if updated.Status.PRMergedAt == nil {
+		t.Error("expected PRMergedAt to be set on tombstone")
+	}
+	// No new RJob.
+	var list v1alpha1.RemediationJobList
+	_ = c.List(context.Background(), &list, client.InNamespace(agentNamespace))
+	if len(list.Items) != 1 {
+		t.Errorf("expected 1 rjob (tombstone only), got %d", len(list.Items))
+	}
+}
+
+// TestDedup_ShortTTLElapsed_ReInvestigates: PR not merged and short TTL elapsed → new RJob created.
+func TestDedup_ShortTTLElapsed_ReInvestigates(t *testing.T) {
+	t.Parallel()
+	finding := &domain.Finding{
+		Kind: "Deployment", Name: "my-app", Namespace: "default",
+		ParentObject: "Deployment/my-app",
+		Errors:       `[{"text":"CrashLoopBackOff"}]`,
+	}
+	fp, _ := domain.FindingFingerprint(finding)
+
+	// Completed 25 hours ago → past 24h short TTL.
+	tombstone := makeSucceededTombstone(fp, time.Now().Add(-25*time.Hour), "https://github.com/org/repo/pull/42", false, nil)
+
+	obj := makeWatchedObject("my-app", "default")
+	c := newTestClient(obj, tombstone)
+	checker := &fakePRMergeChecker{merged: false}
+
+	r := &provider.SourceProviderReconciler{
+		Client: c, Scheme: newTestScheme(),
+		Cfg: config.Config{
+			AgentNamespace:                agentNamespace,
+			RemediationJobShortTTLSeconds: 86400,
+			StabilisationWindow:           0, // disable stabilisation for this test
+		},
+		Provider:       &fakeSourceProvider{name: "native", objectType: &corev1.ConfigMap{}, finding: finding},
+		PRMergeChecker: checker,
+	}
+
+	// First reconcile: tombstone expired → deleted, requeue requested.
+	result, err := r.Reconcile(context.Background(), reqFor("my-app", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error on first reconcile: %v", err)
+	}
+	if !result.Requeue {
+		t.Errorf("expected Requeue=true after tombstone expiry, got %+v", result)
+	}
+
+	// Second reconcile: tombstone gone → new RJob created.
+	_, err = r.Reconcile(context.Background(), reqFor("my-app", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error on second reconcile: %v", err)
+	}
+	var list v1alpha1.RemediationJobList
+	_ = c.List(context.Background(), &list, client.InNamespace(agentNamespace))
+	if len(list.Items) != 1 {
+		t.Errorf("expected 1 new RJob after tombstone deleted; got %d", len(list.Items))
+	}
+	// The new RJob must not be the old tombstone (same name is fine — it's a fresh create).
+	if list.Items[0].Status.Phase == v1alpha1.PhaseSucceeded {
+		t.Error("new RJob should not be in Succeeded phase")
+	}
+}
+
+// TestDedup_NoPR_ShortTTLElapsed_ReInvestigates: no PR opened and short TTL elapsed → new RJob.
+func TestDedup_NoPR_ShortTTLElapsed_ReInvestigates(t *testing.T) {
+	t.Parallel()
+	finding := &domain.Finding{
+		Kind: "Deployment", Name: "my-app", Namespace: "default",
+		ParentObject: "Deployment/my-app",
+		Errors:       `[{"text":"CrashLoopBackOff"}]`,
+	}
+	fp, _ := domain.FindingFingerprint(finding)
+
+	// No PR (empty SinkRef), completed 25h ago.
+	tombstone := makeSucceededTombstone(fp, time.Now().Add(-25*time.Hour), "", false, nil)
+
+	obj := makeWatchedObject("my-app", "default")
+	c := newTestClient(obj, tombstone)
+	checker := &fakePRMergeChecker{} // should not be called
+
+	r := &provider.SourceProviderReconciler{
+		Client: c, Scheme: newTestScheme(),
+		Cfg: config.Config{
+			AgentNamespace:                agentNamespace,
+			RemediationJobShortTTLSeconds: 86400,
+			StabilisationWindow:           0,
+		},
+		Provider:       &fakeSourceProvider{name: "native", objectType: &corev1.ConfigMap{}, finding: finding},
+		PRMergeChecker: checker,
+	}
+
+	// First reconcile: tombstone expired → deleted, requeue.
+	result, err := r.Reconcile(context.Background(), reqFor("my-app", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error on first reconcile: %v", err)
+	}
+	if !result.Requeue {
+		t.Errorf("expected Requeue=true after tombstone expiry, got %+v", result)
+	}
+	if checker.calls != 0 {
+		t.Errorf("expected 0 GitHub calls when no PR exists, got %d", checker.calls)
+	}
+
+	// Second reconcile: tombstone gone → new RJob created.
+	_, err = r.Reconcile(context.Background(), reqFor("my-app", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error on second reconcile: %v", err)
+	}
+	var list v1alpha1.RemediationJobList
+	_ = c.List(context.Background(), &list, client.InNamespace(agentNamespace))
+	if len(list.Items) != 1 {
+		t.Errorf("expected 1 new RJob after no-PR tombstone expired; got %d rjobs", len(list.Items))
+	}
+	if list.Items[0].Status.Phase == v1alpha1.PhaseSucceeded {
+		t.Error("new RJob should not be in Succeeded phase")
+	}
+}
+
+// TestDedup_NoPR_WithinShortTTL_Suppressed: no PR, within 24h → suppress, no GitHub call.
+func TestDedup_NoPR_WithinShortTTL_Suppressed(t *testing.T) {
+	t.Parallel()
+	finding := &domain.Finding{
+		Kind: "Deployment", Name: "my-app", Namespace: "default",
+		ParentObject: "Deployment/my-app",
+		Errors:       `[{"text":"CrashLoopBackOff"}]`,
+	}
+	fp, _ := domain.FindingFingerprint(finding)
+
+	// No PR, completed 1h ago → within 24h.
+	tombstone := makeSucceededTombstone(fp, time.Now().Add(-1*time.Hour), "", false, nil)
+
+	obj := makeWatchedObject("my-app", "default")
+	c := newTestClient(obj, tombstone)
+	checker := &fakePRMergeChecker{}
+
+	r := &provider.SourceProviderReconciler{
+		Client: c, Scheme: newTestScheme(),
+		Cfg:            config.Config{AgentNamespace: agentNamespace, RemediationJobShortTTLSeconds: 86400},
+		Provider:       &fakeSourceProvider{name: "native", objectType: &corev1.ConfigMap{}, finding: finding},
+		PRMergeChecker: checker,
+	}
+
+	_, err := r.Reconcile(context.Background(), reqFor("my-app", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if checker.calls != 0 {
+		t.Errorf("expected 0 GitHub calls, got %d", checker.calls)
+	}
+	var list v1alpha1.RemediationJobList
+	_ = c.List(context.Background(), &list, client.InNamespace(agentNamespace))
+	if len(list.Items) != 1 {
+		t.Errorf("expected 1 rjob (tombstone only), got %d", len(list.Items))
+	}
+}
+
+// TestDedup_MergeCheckerError_SuppressedWithinShortTTL: GitHub error → treat as unmerged, suppress within TTL.
+func TestDedup_MergeCheckerError_SuppressedWithinShortTTL(t *testing.T) {
+	t.Parallel()
+	finding := &domain.Finding{
+		Kind: "Deployment", Name: "my-app", Namespace: "default",
+		ParentObject: "Deployment/my-app",
+		Errors:       `[{"text":"CrashLoopBackOff"}]`,
+	}
+	fp, _ := domain.FindingFingerprint(finding)
+
+	tombstone := makeSucceededTombstone(fp, time.Now().Add(-1*time.Hour), "https://github.com/org/repo/pull/42", false, nil)
+
+	obj := makeWatchedObject("my-app", "default")
+	c := newTestClient(obj, tombstone)
+	checker := &fakePRMergeChecker{merged: false, err: errors.New("rate limited")}
+
+	r := &provider.SourceProviderReconciler{
+		Client: c, Scheme: newTestScheme(),
+		Cfg:            config.Config{AgentNamespace: agentNamespace, RemediationJobShortTTLSeconds: 86400},
+		Provider:       &fakeSourceProvider{name: "native", objectType: &corev1.ConfigMap{}, finding: finding},
+		PRMergeChecker: checker,
+	}
+
+	_, err := r.Reconcile(context.Background(), reqFor("my-app", "default"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Still suppressed because within short TTL.
+	var list v1alpha1.RemediationJobList
+	_ = c.List(context.Background(), &list, client.InNamespace(agentNamespace))
+	if len(list.Items) != 1 {
+		t.Errorf("expected 1 rjob (tombstone) on checker error within TTL, got %d", len(list.Items))
+	}
+}

--- a/internal/sink/github/closer_test.go
+++ b/internal/sink/github/closer_test.go
@@ -17,6 +17,9 @@ import (
 // Compile-time interface check.
 var _ domain.SinkCloser = (*sinkhub.GitHubSinkCloser)(nil)
 
+// errFakeToken is a sentinel error returned by staticTokenProvider when err is set.
+var errFakeToken = fmt.Errorf("fake token error")
+
 // staticTokenProvider is a test double for TokenProvider.
 type staticTokenProvider struct {
 	token string

--- a/internal/sink/github/merge_checker.go
+++ b/internal/sink/github/merge_checker.go
@@ -1,0 +1,86 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	v1alpha1 "github.com/lenaxia/k8s-mechanic/api/v1alpha1"
+	"github.com/lenaxia/k8s-mechanic/internal/domain"
+	igithub "github.com/lenaxia/k8s-mechanic/internal/github"
+)
+
+// Compile-time interface check.
+var _ domain.PRMergeChecker = (*GitHubPRMergeChecker)(nil)
+
+// GitHubPRMergeChecker checks whether a GitHub PR has been merged using the
+// GitHub REST API.
+//
+// It calls GET /repos/{owner}/{repo}/pulls/{number}/merge:
+//   - 204 No Content  → merged
+//   - 404 Not Found   → not merged (PR open or closed without merge)
+//   - other           → transient error, returned to caller
+type GitHubPRMergeChecker struct {
+	TokenProvider igithub.TokenProvider
+	// BaseURL allows overriding the GitHub API endpoint in tests.
+	// Defaults to "https://api.github.com" when empty.
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+// IsMerged returns true if the PR referenced by ref has been merged.
+// Returns (false, nil) if ref.URL is empty or ref.Type is not "pr".
+// Returns (false, nil) on 404 (PR exists but not merged).
+// Returns (false, err) on network or auth errors.
+func (c *GitHubPRMergeChecker) IsMerged(ctx context.Context, ref v1alpha1.SinkRef) (bool, error) {
+	if ref.URL == "" || ref.Type != "pr" {
+		return false, nil
+	}
+	if ref.Number <= 0 {
+		return false, fmt.Errorf("IsMerged: SinkRef.Number must be > 0, got %d", ref.Number)
+	}
+	if ref.Repo == "" {
+		return false, fmt.Errorf("IsMerged: SinkRef.Repo must not be empty")
+	}
+
+	token, err := c.TokenProvider.Token(ctx)
+	if err != nil {
+		return false, fmt.Errorf("IsMerged: getting GitHub token: %w", err)
+	}
+
+	base := c.BaseURL
+	if base == "" {
+		base = "https://api.github.com"
+	}
+	hc := c.HTTPClient
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+
+	// GET /repos/{owner}/{repo}/pulls/{number}/merge
+	// 204 = merged, 404 = not merged, anything else = error.
+	url := fmt.Sprintf("%s/repos/%s/pulls/%d/merge", base, ref.Repo, ref.Number)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false, fmt.Errorf("IsMerged: building request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := hc.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("IsMerged: executing request: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	switch resp.StatusCode {
+	case http.StatusNoContent: // 204
+		return true, nil
+	case http.StatusNotFound: // 404
+		return false, nil
+	default:
+		return false, fmt.Errorf("IsMerged: unexpected status %d for %s", resp.StatusCode, url)
+	}
+}

--- a/internal/sink/github/merge_checker_test.go
+++ b/internal/sink/github/merge_checker_test.go
@@ -1,0 +1,121 @@
+package github_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	v1alpha1 "github.com/lenaxia/k8s-mechanic/api/v1alpha1"
+	"github.com/lenaxia/k8s-mechanic/internal/domain"
+	sinkhub "github.com/lenaxia/k8s-mechanic/internal/sink/github"
+)
+
+// Compile-time interface check.
+var _ domain.PRMergeChecker = (*sinkhub.GitHubPRMergeChecker)(nil)
+
+func newMergeChecker(t *testing.T, token string, mux *routeHandler) (*sinkhub.GitHubPRMergeChecker, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	checker := &sinkhub.GitHubPRMergeChecker{
+		TokenProvider: &staticTokenProvider{token: token},
+		BaseURL:       srv.URL,
+		HTTPClient:    srv.Client(),
+	}
+	return checker, srv
+}
+
+func prRef(repo string, number int) v1alpha1.SinkRef {
+	return v1alpha1.SinkRef{
+		Type:   "pr",
+		URL:    "https://github.com/" + repo + "/pull/42",
+		Number: number,
+		Repo:   repo,
+	}
+}
+
+func TestGitHubPRMergeChecker_Merged(t *testing.T) {
+	mux := &routeHandler{handlers: map[string]http.HandlerFunc{
+		"GET /repos/org/repo/pulls/42/merge": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent) // 204 = merged
+		},
+	}}
+	checker, _ := newMergeChecker(t, "tok", mux)
+	merged, err := checker.IsMerged(context.Background(), prRef("org/repo", 42))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !merged {
+		t.Error("expected merged=true, got false")
+	}
+}
+
+func TestGitHubPRMergeChecker_NotMerged(t *testing.T) {
+	mux := &routeHandler{handlers: map[string]http.HandlerFunc{
+		"GET /repos/org/repo/pulls/42/merge": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound) // 404 = not merged
+		},
+	}}
+	checker, _ := newMergeChecker(t, "tok", mux)
+	merged, err := checker.IsMerged(context.Background(), prRef("org/repo", 42))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if merged {
+		t.Error("expected merged=false, got true")
+	}
+}
+
+func TestGitHubPRMergeChecker_TransientError(t *testing.T) {
+	mux := &routeHandler{handlers: map[string]http.HandlerFunc{
+		"GET /repos/org/repo/pulls/42/merge": func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError) // unexpected → error
+		},
+	}}
+	checker, _ := newMergeChecker(t, "tok", mux)
+	merged, err := checker.IsMerged(context.Background(), prRef("org/repo", 42))
+	if err == nil {
+		t.Fatal("expected error for 500 response, got nil")
+	}
+	if merged {
+		t.Error("expected merged=false on error")
+	}
+}
+
+func TestGitHubPRMergeChecker_EmptyURL(t *testing.T) {
+	checker := &sinkhub.GitHubPRMergeChecker{}
+	merged, err := checker.IsMerged(context.Background(), v1alpha1.SinkRef{})
+	if err != nil {
+		t.Fatalf("unexpected error for empty ref: %v", err)
+	}
+	if merged {
+		t.Error("expected merged=false for empty ref")
+	}
+}
+
+func TestGitHubPRMergeChecker_NonPRType(t *testing.T) {
+	checker := &sinkhub.GitHubPRMergeChecker{}
+	ref := v1alpha1.SinkRef{Type: "issue", URL: "https://github.com/org/repo/issues/1", Number: 1, Repo: "org/repo"}
+	merged, err := checker.IsMerged(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("unexpected error for issue ref: %v", err)
+	}
+	if merged {
+		t.Error("expected merged=false for non-pr type")
+	}
+}
+
+func TestGitHubPRMergeChecker_TokenError(t *testing.T) {
+	checker := &sinkhub.GitHubPRMergeChecker{
+		TokenProvider: &staticTokenProvider{err: errFakeToken},
+		BaseURL:       "http://localhost:1", // unreachable — should fail at token
+	}
+	merged, err := checker.IsMerged(context.Background(), prRef("org/repo", 42))
+	if err == nil {
+		t.Fatal("expected error when token provider fails")
+	}
+	if merged {
+		t.Error("expected merged=false on token error")
+	}
+}


### PR DESCRIPTION
## Problem

All Succeeded RJob tombstones used a single 7-day TTL regardless of whether
the fix PR was ever merged. A problem whose PR was opened but not merged (or
where the agent failed to open a PR) would go uninvestigated for 7 days —
a false negative.

## Solution: two-tier TTL with lazy GitHub merge check

The provider reconciler lazily checks GitHub PR merge state when a finding
hits a Succeeded tombstone:

| Tombstone state | Behavior |
|---|---|
| `PRMerged=true` | Suppress (long TTL: 7d from `PRMergedAt`) |
| PR not yet merged, within 24h of `CompletedAt` | Check GitHub; if merged → patch `PRMerged=true`, suppress; if not → suppress with short TTL |
| PR not merged, 24h elapsed | Delete tombstone + `Requeue: true`; next reconcile creates fresh RJob |
| No PR (`SinkRef.URL==""`) within 24h | Suppress (no GitHub call) |
| No PR, 24h elapsed | Delete tombstone + requeue |
| GitHub API error | Treat as unmerged; fall back to TTL check |

Zero overhead when the cluster is healthy (tombstones have `PRMerged=true` after merge confirmation).

## Changes

- **`api/v1alpha1`**: `PRMerged bool` + `PRMergedAt *Time` on `RemediationJobStatus`
- **`domain/sink.go`**: `PRMergeChecker` interface + `NoopPRMergeChecker`
- **`sink/github/merge_checker.go`**: `GitHubPRMergeChecker` — `GET /repos/{owner}/{repo}/pulls/{n}/merge` (204=merged, 404=not merged)
- **`config`**: `REMEDIATION_JOB_SHORT_TTL_SECONDS` (default `86400` = 24h)
- **`provider/provider.go`**: `PRMergeChecker` field on reconciler; `PhaseSucceeded` dedup case rewritten with lazy merge check and tombstone deletion on TTL expiry
- **`controller/remediationjob_controller.go`**: TTL picks long/short based on `PRMerged`; long TTL clock from `PRMergedAt`
- **`cmd/watcher/main.go`**: `GitHubPRMergeChecker` wired alongside `GitHubSinkCloser`, sharing the same token provider

## Tests
- 7 provider dedup tests (merged, unmerged-within-TTL, just-merged, TTL-elapsed, no-PR-within-TTL, no-PR-expired, checker-error)
- 6 `GitHubPRMergeChecker` unit tests (204, 404, 500, empty URL, issue type, token error)
- All 18 packages pass `go test -race`