### PR TITLE
fix(ci): switch renovate-analysis to pull_request and refresh helm-docs

### DIFF
--- a/.github/workflows/renovate-analysis.yml
+++ b/.github/workflows/renovate-analysis.yml
@@ -1,7 +1,15 @@
 name: Renovate PR Analysis
 
 on:
-  pull_request_target:
+  # Renovate creates branches inside this repo (not forks), so the
+  # plain `pull_request` event is sufficient and avoids the security
+  # pitfalls of `pull_request_target` (executing untrusted PR code with
+  # the base-branch token). The opencode action also explicitly does not
+  # support `pull_request_target` — its SUPPORTED_EVENTS list only
+  # includes `pull_request`, `issues`, `issue_comment`,
+  # `pull_request_review_comment`, `schedule`, and `workflow_dispatch`.
+  # See: anomalyco/opencode packages/opencode/src/cli/cmd/github.ts
+  pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
@@ -16,7 +24,8 @@ env:
 
 jobs:
   analyze-prs:
-    # Only run for Renovate PRs or manual triggers
+    # Only run for Renovate PRs (when triggered via pull_request) or any
+    # manual / scheduled trigger (workflow_dispatch).
     if: |
       github.event_name != 'pull_request' ||
       github.event.pull_request.user.login == 'renovate[bot]'

--- a/charts/mechanic/README.md
+++ b/charts/mechanic/README.md
@@ -1,6 +1,6 @@
 # mechanic
 
-![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.4](https://img.shields.io/badge/AppVersion-v0.4.4-informational?style=flat-square)
+![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.4.5](https://img.shields.io/badge/AppVersion-v0.4.5-informational?style=flat-square)
 
 Kubernetes-native SRE remediation bot — watches cluster failures, spawns an LLM agent, and opens GitOps pull requests with proposed fixes.
 
@@ -77,7 +77,7 @@ kubectl delete crd remediationjobs.remediation.mechanic.io
 | agent.rbac | object | `{"scope":"cluster","watchNamespaces":""}` | RBAC configuration for agent Jobs. |
 | agent.rbac.scope | string | `"cluster"` | RBAC scope for the agent Job. One of "cluster" (default) or "namespace". When "namespace", watchNamespaces must also be set. |
 | agent.rbac.watchNamespaces | string | `""` | Comma-separated list of namespaces the agent is permitted to read when scope is "namespace". Example: "production,staging". |
-| agent.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Resource requests and limits applied to all agent Job containers. |
+| agent.resources | object | `{}` | Resource requests and limits applied to all agent Job containers. Set to {} or omit individual sub-keys to apply no limits. |
 | agent.security | object | `{"hardening":{"enabled":false,"extraRedactPatterns":[]},"kyverno":{"allowedImagePrefix":"ghcr.io/lenaxia/mechanic-agent","enabled":false},"networkPolicy":{"additionalEgressRules":[],"apiServerPort":6443,"enabled":false}}` | Security hardening for agent Jobs. |
 | agent.security.hardening | object | `{"enabled":false,"extraRedactPatterns":[]}` | Tool output redaction and kubectl restrictions. |
 | agent.security.hardening.enabled | bool | `false` | Block kubectl get/describe secret(s), get all, exec, and port-forward in agent Jobs. Off by default — disabling exec limits the agent's ability to inspect running containers. |
@@ -129,7 +129,7 @@ kubectl delete crd remediationjobs.remediation.mechanic.io
 | watcher.maxInvestigationRetries | int | `3` | Maximum number of investigation retries per RemediationJob before permanently failing. |
 | watcher.prAutoClose | bool | `true` | Automatically close open GitHub PRs when the underlying finding resolves. Set to false to leave PRs open for manual review. |
 | watcher.remediationJobTTLSeconds | int | `604800` | Time-to-live for completed RemediationJob objects in seconds. Default is 7 days. |
-| watcher.resources | object | `{"limits":{"cpu":"200m","memory":"128Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | Resource requests and limits for the watcher Deployment container. |
+| watcher.resources | object | `{}` | Resource requests and limits for the watcher Deployment container. Set to {} or omit individual sub-keys to apply no limits. |
 | watcher.sinkType | string | `"github"` | Sink type for PR creation. Currently only "github" is supported. |
 | watcher.stabilisationWindowSeconds | int | `120` | Seconds to wait after first detecting a failure before creating a RemediationJob. Set to 0 to dispatch immediately. |
 | watcher.watchNamespaces | string | `""` | Comma-separated list of namespaces the watcher monitors for failures. Empty means all namespaces. |


### PR DESCRIPTION
## Summary

Two CI workflows have been failing on `main`. This PR fixes both:

1. **Renovate PR Analysis** — switched trigger from `pull_request_target` to `pull_request`.
2. **Docs — check generated files are up to date** — regenerated `charts/mechanic/README.md`.

## Renovate PR Analysis fix

Every run on a Renovate PR was failing with:

> ##[error]Unsupported event type: pull_request_target

The `anomalyco/opencode` action explicitly limits itself to a fixed list of events in `packages/opencode/src/cli/cmd/github.ts`:

```
USER_EVENTS = ["issue_comment", "pull_request_review_comment", "issues", "pull_request"]
REPO_EVENTS = ["schedule", "workflow_dispatch"]
```

`pull_request_target` is not supported. Switching to `pull_request` is safe because Renovate creates its branches inside this repository (not external forks), so:

- `GITHUB_TOKEN` write/secrets restrictions that motivate `pull_request_target` do not apply.
- The opencode OIDC app-token exchange (`id-token: write`) works identically.
- The existing `renovate[bot]`-only job filter remains effective.

As a side benefit, this removes the well-known security pitfall of `pull_request_target` (executing PR code with the trusted base-branch token).

## Docs fix

`make docs` was producing a diff against `charts/mechanic/README.md` because:

1. `Chart.yaml` advanced to `v0.4.5` after `chart-version-bump.yaml` ran on the most recent release tag, but the regenerated README was not committed.
2. `agent.resources` and `watcher.resources` defaults flipped to `{}` in `values.yaml` (with the `artifacthub.io/changes` annotation noting it), but `helm-docs` had not been re-run.

This commit re-runs `make docs generate` and commits the resulting README.

## Test plan

- `make docs generate` is now a no-op (verified locally with helm-docs 1.14.2, crd-ref-docs v0.3.0, controller-gen v0.19.0 — same versions as the Docs workflow).
- The Renovate PR Analysis workflow on this PR will run with the new `pull_request` trigger; verifying it reaches the opencode step instead of failing at the `Unsupported event type` check.

## Notes

- This PR was opened on a `bugfix/` branch per CONTRIBUTING.md.
- No CRD or RBAC changes; nothing security-sensitive.
- This is a CI-only change; runtime behaviour of the operator is unaffected.